### PR TITLE
Validation Module

### DIFF
--- a/apps/cli/src/use-cases/seed/parser.service.ts
+++ b/apps/cli/src/use-cases/seed/parser.service.ts
@@ -94,6 +94,11 @@ export class ParserService {
         key: field.property,
         name: pascalCaseToWords(field.property),
         description: field.description,
+        validationRules: {
+          general: {
+            nullable: true,
+          },
+        },
         fieldType:
           (await getTypeForApi(field, atom, this.userId))?.existingId ?? '',
       })),

--- a/libs/backend/adapter/neo4j/src/cypher/type/field/connectField.cypher
+++ b/libs/backend/adapter/neo4j/src/cypher/type/field/connectField.cypher
@@ -12,7 +12,7 @@ MERGE (interfaceType)-
       key: $field.key,
       name: coalesce($field.name, ""),
       description: coalesce($field.description, ""),
-      validationSchema: coalesce($field.validationSchema, "")
+      validationRules: coalesce($field.validationRules, "")
     }
   ]->(fieldType)
 

--- a/libs/backend/adapter/neo4j/src/cypher/type/field/connectField.cypher
+++ b/libs/backend/adapter/neo4j/src/cypher/type/field/connectField.cypher
@@ -11,7 +11,8 @@ MERGE (interfaceType)-
       id: $field.id,
       key: $field.key,
       name: coalesce($field.name, ""),
-      description: coalesce($field.description, "")
+      description: coalesce($field.description, ""),
+      validationSchema: coalesce($field.validationSchema, "")
     }
   ]->(fieldType)
 

--- a/libs/backend/adapter/neo4j/src/schema/type/field.schema.ts
+++ b/libs/backend/adapter/neo4j/src/schema/type/field.schema.ts
@@ -6,6 +6,7 @@ input FieldCreateInput {
   id: ID!
   key: String!
   name: String
+  validationSchema: String
 }
 `
 
@@ -15,6 +16,7 @@ export const fieldSchema = gql`
     key: String!
     name: String
     description: String
+    validationSchema: String
   }
 
   ${sdl}

--- a/libs/backend/adapter/neo4j/src/schema/type/field.schema.ts
+++ b/libs/backend/adapter/neo4j/src/schema/type/field.schema.ts
@@ -6,7 +6,7 @@ input FieldCreateInput {
   id: ID!
   key: String!
   name: String
-  validationSchema: String
+  validationRules: String
 }
 `
 
@@ -16,7 +16,7 @@ export const fieldSchema = gql`
     key: String!
     name: String
     description: String
-    validationSchema: String
+    validationRules: String
   }
 
   ${sdl}

--- a/libs/backend/adapter/neo4j/src/selectionSets/typeSelectionSet.ts
+++ b/libs/backend/adapter/neo4j/src/selectionSets/typeSelectionSet.ts
@@ -54,7 +54,7 @@ export const exportInterfaceTypeSelectionSet = `{
       key
       name
       description
-      validationSchema
+      validationRules
       node {
         ${exportBaseSelection}
       }
@@ -75,7 +75,7 @@ export const interfaceTypeSelectionSet = `{
       key
       name
       description
-      validationSchema
+      validationRules
       node {
         ${exportBaseSelection}
       }

--- a/libs/backend/adapter/neo4j/src/selectionSets/typeSelectionSet.ts
+++ b/libs/backend/adapter/neo4j/src/selectionSets/typeSelectionSet.ts
@@ -54,6 +54,7 @@ export const exportInterfaceTypeSelectionSet = `{
       key
       name
       description
+      validationSchema
       node {
         ${exportBaseSelection}
       }
@@ -74,6 +75,7 @@ export const interfaceTypeSelectionSet = `{
       key
       name
       description
+      validationSchema
       node {
         ${exportBaseSelection}
       }

--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -50,7 +50,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     )
 
     const onSubmit = (data: IPropData) => {
-      console.log(data)
+      console.log('Submitting: ', data)
 
       const promise = elementService.patchElement(element, {
         props: {

--- a/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
@@ -123,7 +123,9 @@ export class TypeSchemaFactory {
       properties: [...type.fields.values()].reduce(makeFieldProperties, {}),
       required: [...type.fields.values()]
         .map((field) =>
-          field.validationRules?.general.nullable ? undefined : field.key,
+          field.validationRules?.general?.nullable === false
+            ? field.key
+            : undefined,
         )
         .filter(Boolean) as Array<string>,
     }
@@ -203,17 +205,17 @@ export class TypeSchemaFactory {
     switch (type.primitiveKind) {
       case PrimitiveTypeKind.String:
         validation = {
-          ...context?.validationRules?.string,
+          ...context?.validationRules?.String,
         }
         break
       case PrimitiveTypeKind.Float:
         validation = {
-          ...context?.validationRules?.float,
+          ...context?.validationRules?.Float,
         }
         break
       case PrimitiveTypeKind.Integer:
         validation = {
-          ...context?.validationRules?.integer,
+          ...context?.validationRules?.Integer,
         }
         break
     }

--- a/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
@@ -99,6 +99,7 @@ export class TypeSchemaFactory {
   fromInterfaceType(type: IInterfaceType): JsonSchema {
     const makeFieldSchema = (field: IField) => ({
       ...this.transform(field.type.current),
+      ...JSON.parse(field.validationSchema || '{}'),
       label: field.name || pascalCaseToWords(field.key),
     })
 

--- a/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/modules/type/src/interface-form/type-schema.factory.ts
@@ -99,9 +99,9 @@ export class TypeSchemaFactory {
   fromInterfaceType(type: IInterfaceType): JsonSchema {
     const makeFieldSchema = (field: IField) => ({
       ...this.transform(field.type.current, {
-        validationSchema: field.validationSchema ?? undefined,
+        validationRules: field.validationRules ?? undefined,
       }),
-      ...field?.validationSchema?.general,
+      ...field?.validationRules?.general,
       label: field.name || pascalCaseToWords(field.key),
     })
 
@@ -123,7 +123,7 @@ export class TypeSchemaFactory {
       properties: [...type.fields.values()].reduce(makeFieldProperties, {}),
       required: [...type.fields.values()]
         .map((field) =>
-          field.validationSchema?.general.nullable ? undefined : field.key,
+          field.validationRules?.general.nullable ? undefined : field.key,
         )
         .filter(Boolean) as Array<string>,
     }
@@ -203,17 +203,17 @@ export class TypeSchemaFactory {
     switch (type.primitiveKind) {
       case PrimitiveTypeKind.String:
         validation = {
-          ...context?.validationSchema?.string,
+          ...context?.validationRules?.string,
         }
         break
       case PrimitiveTypeKind.Float:
         validation = {
-          ...context?.validationSchema?.float,
+          ...context?.validationRules?.float,
         }
         break
       case PrimitiveTypeKind.Integer:
         validation = {
-          ...context?.validationSchema?.integer,
+          ...context?.validationRules?.integer,
         }
         break
     }

--- a/libs/frontend/modules/type/src/interface-form/types.ts
+++ b/libs/frontend/modules/type/src/interface-form/types.ts
@@ -4,7 +4,7 @@ import {
   IAnyType,
   IInterfaceType,
   IPropData,
-  IValidationSchema,
+  IValidationRules,
 } from '@codelab/shared/abstract/core'
 import { Assign } from 'utility-types'
 
@@ -32,5 +32,5 @@ export interface UiPropertiesContext {
    * for code mirror
    */
   autocomplete?: IPropData
-  validationSchema?: IValidationSchema
+  validationRules?: IValidationRules
 }

--- a/libs/frontend/modules/type/src/interface-form/types.ts
+++ b/libs/frontend/modules/type/src/interface-form/types.ts
@@ -4,6 +4,7 @@ import {
   IAnyType,
   IInterfaceType,
   IPropData,
+  IValidationSchema,
 } from '@codelab/shared/abstract/core'
 import { Assign } from 'utility-types'
 
@@ -31,4 +32,5 @@ export interface UiPropertiesContext {
    * for code mirror
    */
   autocomplete?: IPropData
+  validationSchema?: IValidationSchema
 }

--- a/libs/frontend/modules/type/src/store/models/field.model.ts
+++ b/libs/frontend/modules/type/src/store/models/field.model.ts
@@ -17,14 +17,15 @@ import {
 import { typeRef } from './union-type.model'
 
 const hydrate = (data: IFieldProps) => {
-  const { id, key, name, description, fieldType } = data
+  const { id, key, name, description, fieldType, validationSchema } = data
 
   return new Field({
     id,
-    type: typeRef(fieldType.id),
     name,
     description,
     key,
+    type: typeRef(fieldType.id),
+    validationSchema,
   })
 }
 
@@ -37,6 +38,7 @@ export class Field
     description: prop<Nullish<string>>(),
     key: prop<string>(),
     type: prop<Ref<IAnyType>>(),
+    validationSchema: prop<Nullish<string>>(),
   }))
   implements IField
 {
@@ -47,6 +49,7 @@ export class Field
     this.description = fragment.description
     this.key = fragment.key
     this.type = typeRef(fragment.fieldType.id)
+    this.validationSchema = fragment.validationSchema
 
     return this
   }

--- a/libs/frontend/modules/type/src/store/models/field.model.ts
+++ b/libs/frontend/modules/type/src/store/models/field.model.ts
@@ -2,7 +2,7 @@ import type {
   IAnyType,
   IField,
   IFieldProps,
-  IValidationSchema,
+  IValidationRules,
 } from '@codelab/shared/abstract/core'
 import type { Nullish } from '@codelab/shared/abstract/types'
 import {
@@ -24,10 +24,10 @@ const hydrate = (data: IFieldProps) => {
     name,
     description,
     fieldType,
-    validationSchema: schemaStr,
+    validationRules: schemaStr,
   } = data
 
-  const validationSchema = JSON.parse(schemaStr || '{}')
+  const validationRules = JSON.parse(schemaStr || '{}')
 
   return new Field({
     id,
@@ -35,7 +35,7 @@ const hydrate = (data: IFieldProps) => {
     description,
     key,
     type: typeRef(fieldType.id),
-    validationSchema,
+    validationRules,
   })
 }
 
@@ -48,7 +48,7 @@ export class Field
     description: prop<Nullish<string>>(),
     key: prop<string>(),
     type: prop<Ref<IAnyType>>(),
-    validationSchema: prop<IValidationSchema>(),
+    validationRules: prop<IValidationRules>(),
   }))
   implements IField
 {
@@ -59,7 +59,7 @@ export class Field
     this.description = fragment.description
     this.key = fragment.key
     this.type = typeRef(fragment.fieldType.id)
-    this.validationSchema = JSON.parse(fragment.validationSchema || '{}')
+    this.validationRules = JSON.parse(fragment.validationRules || '{}')
 
     return this
   }

--- a/libs/frontend/modules/type/src/store/models/field.model.ts
+++ b/libs/frontend/modules/type/src/store/models/field.model.ts
@@ -2,6 +2,7 @@ import type {
   IAnyType,
   IField,
   IFieldProps,
+  IValidationSchema,
 } from '@codelab/shared/abstract/core'
 import type { Nullish } from '@codelab/shared/abstract/types'
 import {
@@ -17,7 +18,16 @@ import {
 import { typeRef } from './union-type.model'
 
 const hydrate = (data: IFieldProps) => {
-  const { id, key, name, description, fieldType, validationSchema } = data
+  const {
+    id,
+    key,
+    name,
+    description,
+    fieldType,
+    validationSchema: schemaStr,
+  } = data
+
+  const validationSchema = JSON.parse(schemaStr || '{}')
 
   return new Field({
     id,
@@ -38,7 +48,7 @@ export class Field
     description: prop<Nullish<string>>(),
     key: prop<string>(),
     type: prop<Ref<IAnyType>>(),
-    validationSchema: prop<Nullish<string>>(),
+    validationSchema: prop<IValidationSchema>(),
   }))
   implements IField
 {
@@ -49,7 +59,7 @@ export class Field
     this.description = fragment.description
     this.key = fragment.key
     this.type = typeRef(fragment.fieldType.id)
-    this.validationSchema = fragment.validationSchema
+    this.validationSchema = JSON.parse(fragment.validationSchema || '{}')
 
     return this
   }

--- a/libs/frontend/modules/type/src/store/models/field.model.ts
+++ b/libs/frontend/modules/type/src/store/models/field.model.ts
@@ -48,7 +48,7 @@ export class Field
     description: prop<Nullish<string>>(),
     key: prop<string>(),
     type: prop<Ref<IAnyType>>(),
-    validationRules: prop<IValidationRules>(),
+    validationRules: prop<Nullish<IValidationRules>>(),
   }))
   implements IField
 {

--- a/libs/frontend/modules/type/src/store/tests/typeTreeToJsonSchemaTestData.ts
+++ b/libs/frontend/modules/type/src/store/tests/typeTreeToJsonSchemaTestData.ts
@@ -121,4 +121,5 @@ export const interfaceWithUnionExpectedSchema = {
       ],
     },
   },
+  required: [],
 }

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -284,6 +284,16 @@ export class TypeService
         id: data.id,
         key: data.key,
         name: data.name,
+        validationSchema: JSON.stringify(
+          data.rules?.reduce((acc, rule) => {
+            const { name, value } = rule
+
+            return {
+              ...acc,
+              [name]: value,
+            }
+          }, {}),
+        ),
       },
     }
 

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -297,9 +297,7 @@ export class TypeService
         id: data.id,
         key: data.key,
         name: data.name,
-        validationSchema: JSON.stringify({
-          ...data.validationSchema,
-        }),
+        validationSchema: JSON.stringify(data.validationSchema),
       },
     }
 
@@ -334,9 +332,7 @@ export class TypeService
         description: data.description,
         key: data.key,
         name: data.name,
-        validationSchema: JSON.stringify({
-          ...data.validationSchema,
-        }),
+        validationSchema: JSON.stringify(data.validationSchema),
       },
     }
 

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -297,7 +297,7 @@ export class TypeService
         id: data.id,
         key: data.key,
         name: data.name,
-        validationSchema: JSON.stringify(data.validationSchema),
+        validationRules: JSON.stringify(data.validationRules),
       },
     }
 
@@ -332,7 +332,7 @@ export class TypeService
         description: data.description,
         key: data.key,
         name: data.name,
-        validationSchema: JSON.stringify(data.validationSchema),
+        validationRules: JSON.stringify(data.validationRules),
       },
     }
 

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -289,18 +289,6 @@ export class TypeService
     interfaceTypeId: IInterfaceTypeRef,
     data: ICreateFieldDTO,
   ) {
-    // TODO: make code DRY (same code used in updateField)
-    const primitiveKind = this.primitiveKind(data.fieldType)
-
-    const validationSchemaType =
-      primitiveKind === 'String'
-        ? { type: 'string' }
-        : primitiveKind === 'Integer'
-        ? { type: 'integer' }
-        : primitiveKind === 'Float'
-        ? { type: 'number' }
-        : {}
-
     const input = {
       interfaceTypeId,
       fieldTypeId: data.fieldType,
@@ -310,7 +298,6 @@ export class TypeService
         key: data.key,
         name: data.name,
         validationSchema: JSON.stringify({
-          ...validationSchemaType,
           ...data.validationSchema,
         }),
       },
@@ -338,16 +325,6 @@ export class TypeService
     assertIsTypeKind(interfaceType.kind, ITypeKind.InterfaceType)
 
     const field = throwIfUndefined(interfaceType.field(data.id))
-    const primitiveKind = this.primitiveKind(data.fieldType)
-
-    const validationSchemaType =
-      primitiveKind === 'String'
-        ? { type: 'string' }
-        : primitiveKind === 'Integer'
-        ? { type: 'integer' }
-        : primitiveKind === 'Float'
-        ? { type: 'number' }
-        : {}
 
     const input = {
       interfaceTypeId,
@@ -358,7 +335,6 @@ export class TypeService
         key: data.key,
         name: data.name,
         validationSchema: JSON.stringify({
-          ...validationSchemaType,
           ...data.validationSchema,
         }),
       },

--- a/libs/frontend/modules/type/src/store/type.service.ts
+++ b/libs/frontend/modules/type/src/store/type.service.ts
@@ -289,15 +289,16 @@ export class TypeService
     interfaceTypeId: IInterfaceTypeRef,
     data: ICreateFieldDTO,
   ) {
+    // TODO: make code DRY (same code used in updateField)
     const primitiveKind = this.primitiveKind(data.fieldType)
 
-    const typeSpecificValidationRules =
+    const validationSchemaType =
       primitiveKind === 'String'
-        ? { type: 'string', ...data.stringValidationRules }
+        ? { type: 'string' }
         : primitiveKind === 'Integer'
-        ? { type: 'integer', ...data.integerValidationRules }
+        ? { type: 'integer' }
         : primitiveKind === 'Float'
-        ? { type: 'number', ...data.floatValidationRules }
+        ? { type: 'number' }
         : {}
 
     const input = {
@@ -309,8 +310,8 @@ export class TypeService
         key: data.key,
         name: data.name,
         validationSchema: JSON.stringify({
-          ...data.generalValidationRules,
-          ...typeSpecificValidationRules,
+          ...validationSchemaType,
+          ...data.validationSchema,
         }),
       },
     }
@@ -337,6 +338,16 @@ export class TypeService
     assertIsTypeKind(interfaceType.kind, ITypeKind.InterfaceType)
 
     const field = throwIfUndefined(interfaceType.field(data.id))
+    const primitiveKind = this.primitiveKind(data.fieldType)
+
+    const validationSchemaType =
+      primitiveKind === 'String'
+        ? { type: 'string' }
+        : primitiveKind === 'Integer'
+        ? { type: 'integer' }
+        : primitiveKind === 'Float'
+        ? { type: 'number' }
+        : {}
 
     const input = {
       interfaceTypeId,
@@ -346,6 +357,10 @@ export class TypeService
         description: data.description,
         key: data.key,
         name: data.name,
+        validationSchema: JSON.stringify({
+          ...validationSchemaType,
+          ...data.validationSchema,
+        }),
       },
     }
 

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
@@ -18,7 +18,7 @@ const generateDefaultFormModel = () =>
     id: v4(),
     key: '',
     fieldType: '',
-    validationSchema: {
+    validationRules: {
       general: {
         nullable: true,
       },
@@ -64,18 +64,18 @@ export const CreateFieldModal = observer<CreateFieldModalProps>(
             setModel((prev) => {
               const newVal: ICreateFieldDTO = {
                 ...prev,
-                validationSchema: {
+                validationRules: {
                   general: {
-                    ...prev.validationSchema.general,
+                    ...prev.validationRules.general,
                   },
                   string: {
-                    ...prev.validationSchema.string,
+                    ...prev.validationRules.string,
                   },
                   float: {
-                    ...prev.validationSchema.float,
+                    ...prev.validationRules.float,
                   },
                   integer: {
-                    ...prev.validationSchema.integer,
+                    ...prev.validationRules.integer,
                   },
                 },
               }
@@ -101,28 +101,28 @@ export const CreateFieldModal = observer<CreateFieldModalProps>(
           }}
           schema={createFieldSchema}
         >
-          <AutoFields omitFields={['fieldType', 'validationSchema']} />
+          <AutoFields omitFields={['fieldType', 'validationRules']} />
           <TypeSelect
             label="Type"
             name="fieldType"
             types={typeService.typesList}
           />
 
-          <AutoFields fields={['validationSchema.general']} />
+          <AutoFields fields={['validationRules.general']} />
 
           {model.fieldType &&
             typeService.primitiveKind(model.fieldType) === 'String' && (
-              <AutoFields fields={['validationSchema.string']} />
+              <AutoFields fields={['validationRules.string']} />
             )}
 
           {model.fieldType &&
             typeService.primitiveKind(model.fieldType) === 'Integer' && (
-              <AutoFields fields={['validationSchema.integer']} />
+              <AutoFields fields={['validationRules.integer']} />
             )}
 
           {model.fieldType &&
             typeService.primitiveKind(model.fieldType) === 'Float' && (
-              <AutoFields fields={['validationSchema.float']} />
+              <AutoFields fields={['validationRules.float']} />
             )}
         </ModalForm.Form>
       </ModalForm.Modal>

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/CreateFieldModal.tsx
@@ -42,14 +42,20 @@ export const CreateFieldModal = observer<CreateFieldModalProps>(
           onChange={(key, value) => {
             setData((prev) => {
               // TODO: definetly improve this (works for only 1 level of nesting)
-              const rootKey = key.split('.')[0]
-              const nestedKey = key.split('.')[1]
 
-              const valueToSet = nestedKey
-                ? { ...(prev as any)[rootKey], [nestedKey]: value }
-                : value
+              if (key.split('.')[0] === 'validationSchema') {
+                const nestedKey = key.split('.')[1]
 
-              return { ...prev, [rootKey]: valueToSet }
+                return {
+                  ...prev,
+                  validationSchema: {
+                    ...prev.validationSchema,
+                    [nestedKey]: value,
+                  },
+                }
+              }
+
+              return { ...prev, [key]: value }
             })
           }}
           onSubmit={(input) =>
@@ -68,36 +74,50 @@ export const CreateFieldModal = observer<CreateFieldModalProps>(
           }}
           schema={createFieldSchema}
         >
-          <AutoFields
-            omitFields={[
-              'fieldType',
-              'generalValidationRules',
-              'stringValidationRules',
-              'integerValidationRules',
-              'floatValidationRules',
-            ]}
-          />
+          <AutoFields omitFields={['fieldType', 'validationSchema']} />
           <TypeSelect
             label="Type"
             name="fieldType"
             types={typeService.typesList}
           />
 
-          <AutoFields fields={['generalValidationRules']} />
+          <AutoFields fields={['validationSchema.nullable']} />
 
           {data.fieldType &&
             typeService.primitiveKind(data.fieldType) === 'String' && (
-              <AutoFields fields={['stringValidationRules']} />
+              <AutoFields
+                fields={[
+                  'validationSchema.minLength',
+                  'validationSchema.maxLength',
+                  'validationSchema.pattern',
+                ]}
+              />
             )}
 
           {data.fieldType &&
             typeService.primitiveKind(data.fieldType) === 'Integer' && (
-              <AutoFields fields={['integerValidationRules']} />
+              <AutoFields
+                fields={[
+                  'validationSchema.minimum',
+                  'validationSchema.maximum',
+                  'validationSchema.exclusiveMaximum',
+                  'validationSchema.exclusiveMinimum',
+                  'validationSchema.multipleOf',
+                ]}
+              />
             )}
 
           {data.fieldType &&
             typeService.primitiveKind(data.fieldType) === 'Float' && (
-              <AutoFields fields={['floatValidationRules']} />
+              <AutoFields
+                fields={[
+                  'validationSchema.minimum',
+                  'validationSchema.maximum',
+                  'validationSchema.exclusiveMaximum',
+                  'validationSchema.exclusiveMinimum',
+                  'validationSchema.multipleOf',
+                ]}
+              />
             )}
         </ModalForm.Form>
       </ModalForm.Modal>

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -9,37 +9,14 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
     key: { type: 'string', autoFocus: true },
     name: { type: 'string', nullable: true },
     description: { type: 'string', nullable: true },
-    generalValidationRules: {
+    validationSchema: {
       type: 'object',
       nullable: true,
       properties: {
         nullable: { type: 'boolean', nullable: true },
-      },
-    },
-    stringValidationRules: {
-      type: 'object',
-      nullable: true,
-      properties: {
         minLength: { type: 'integer', nullable: true, minimum: 0 },
         maxLength: { type: 'integer', nullable: true, minimum: 0 },
         pattern: { type: 'string', nullable: true },
-      },
-    },
-    integerValidationRules: {
-      type: 'object',
-      nullable: true,
-      properties: {
-        maximum: { type: 'integer', nullable: true },
-        minimum: { type: 'integer', nullable: true },
-        exclusiveMaximum: { type: 'integer', nullable: true },
-        exclusiveMinimum: { type: 'integer', nullable: true },
-        multipleOf: { type: 'integer', nullable: true },
-      },
-    },
-    floatValidationRules: {
-      type: 'object',
-      nullable: true,
-      properties: {
         maximum: { type: 'number', nullable: true },
         minimum: { type: 'number', nullable: true },
         exclusiveMaximum: { type: 'number', nullable: true },

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -1,4 +1,9 @@
-import { ICreateFieldDTO } from '@codelab/shared/abstract/core'
+import {
+  GeneralValidationRules,
+  ICreateFieldDTO,
+  NumberValidationRules,
+  StringValidationRules,
+} from '@codelab/shared/abstract/core'
 import { JSONSchemaType } from 'ajv'
 
 export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
@@ -13,16 +18,86 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
       type: 'object',
       nullable: true,
       properties: {
-        nullable: { type: 'boolean', nullable: true },
-        minLength: { type: 'integer', nullable: true, minimum: 0 },
-        maxLength: { type: 'integer', nullable: true, minimum: 0 },
-        pattern: { type: 'string', nullable: true },
-        maximum: { type: 'number', nullable: true },
-        minimum: { type: 'number', nullable: true },
-        exclusiveMaximum: { type: 'number', nullable: true },
-        exclusiveMinimum: { type: 'number', nullable: true },
-        multipleOf: { type: 'number', nullable: true },
+        general: {
+          type: 'object',
+          nullable: false,
+          properties: {
+            [GeneralValidationRules.Nullable]: {
+              type: 'boolean',
+              nullable: false,
+            },
+          },
+          required: [GeneralValidationRules.Nullable],
+        },
+        string: {
+          type: 'object',
+          nullable: true,
+          properties: {
+            [StringValidationRules.MinLength]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [StringValidationRules.MaxLength]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [StringValidationRules.Pattern]: { type: 'string', nullable: true },
+          },
+        },
+        float: {
+          type: 'object',
+          nullable: true,
+          properties: {
+            [NumberValidationRules.Minimum]: {
+              type: 'number',
+              nullable: true,
+            },
+            [NumberValidationRules.Maximum]: {
+              type: 'number',
+              nullable: true,
+            },
+            [NumberValidationRules.ExclusiveMinimum]: {
+              type: 'number',
+              nullable: true,
+            },
+            [NumberValidationRules.ExclusiveMaximum]: {
+              type: 'number',
+              nullable: true,
+            },
+            [NumberValidationRules.MultipleOf]: {
+              type: 'number',
+              nullable: true,
+            },
+          },
+        },
+        integer: {
+          type: 'object',
+          nullable: true,
+          properties: {
+            [NumberValidationRules.Minimum]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [NumberValidationRules.Maximum]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [NumberValidationRules.ExclusiveMinimum]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [NumberValidationRules.ExclusiveMaximum]: {
+              type: 'integer',
+              nullable: true,
+            },
+            [NumberValidationRules.MultipleOf]: {
+              type: 'integer',
+              nullable: true,
+            },
+          },
+        },
       },
+      required: ['general'],
     },
     /**
      * TODO: Refactor to match interface
@@ -30,5 +105,5 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
      */
     fieldType: { type: 'string', nullable: true },
   },
-  required: ['id', 'key', 'fieldType'],
+  required: ['id', 'key', 'fieldType', 'validationSchema'],
 }

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -16,7 +16,8 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
         type: 'object',
         properties: {
           name: { type: 'string' },
-          value: { type: 'string' },
+          // TODO: Accept types other than number based on the validation key
+          value: { type: 'number' },
         },
         required: ['name', 'value'],
       },

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -14,7 +14,7 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
     key: { type: 'string', autoFocus: true },
     name: { type: 'string', nullable: true },
     description: { type: 'string', nullable: true },
-    validationSchema: {
+    validationRules: {
       type: 'object',
       nullable: true,
       properties: {
@@ -105,5 +105,5 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
      */
     fieldType: { type: 'string', nullable: true },
   },
-  required: ['id', 'key', 'fieldType', 'validationSchema'],
+  required: ['id', 'key', 'fieldType', 'validationRules'],
 }

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -9,17 +9,42 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
     key: { type: 'string', autoFocus: true },
     name: { type: 'string', nullable: true },
     description: { type: 'string', nullable: true },
-    rules: {
-      type: 'array',
+    generalValidationRules: {
+      type: 'object',
       nullable: true,
-      items: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          // TODO: Accept types other than number based on the validation key
-          value: { type: 'number' },
-        },
-        required: ['name', 'value'],
+      properties: {
+        nullable: { type: 'boolean', nullable: true },
+      },
+    },
+    stringValidationRules: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        minLength: { type: 'integer', nullable: true, minimum: 0 },
+        maxLength: { type: 'integer', nullable: true, minimum: 0 },
+        pattern: { type: 'string', nullable: true },
+      },
+    },
+    integerValidationRules: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        maximum: { type: 'integer', nullable: true },
+        minimum: { type: 'integer', nullable: true },
+        exclusiveMaximum: { type: 'integer', nullable: true },
+        exclusiveMinimum: { type: 'integer', nullable: true },
+        multipleOf: { type: 'integer', nullable: true },
+      },
+    },
+    floatValidationRules: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        maximum: { type: 'number', nullable: true },
+        minimum: { type: 'number', nullable: true },
+        exclusiveMaximum: { type: 'number', nullable: true },
+        exclusiveMinimum: { type: 'number', nullable: true },
+        multipleOf: { type: 'number', nullable: true },
       },
     },
     /**

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -9,6 +9,18 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
     key: { type: 'string', autoFocus: true },
     name: { type: 'string', nullable: true },
     description: { type: 'string', nullable: true },
+    rules: {
+      type: 'array',
+      nullable: true,
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          value: { type: 'string' },
+        },
+        required: ['name', 'value'],
+      },
+    },
     /**
      * TODO: Refactor to match interface
      * Could somehow modify the form so we can accept an object of TypeRef, then the interface would match up better

--- a/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
+++ b/libs/frontend/modules/type/src/use-cases/fields/create-field/createFieldSchema.ts
@@ -1,3 +1,4 @@
+import { PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import {
   GeneralValidationRules,
   ICreateFieldDTO,
@@ -20,16 +21,15 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
       properties: {
         general: {
           type: 'object',
-          nullable: false,
+          nullable: true,
           properties: {
             [GeneralValidationRules.Nullable]: {
               type: 'boolean',
-              nullable: false,
+              nullable: true,
             },
           },
-          required: [GeneralValidationRules.Nullable],
         },
-        string: {
+        [PrimitiveTypeKind.String]: {
           type: 'object',
           nullable: true,
           properties: {
@@ -44,7 +44,7 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
             [StringValidationRules.Pattern]: { type: 'string', nullable: true },
           },
         },
-        float: {
+        [PrimitiveTypeKind.Float]: {
           type: 'object',
           nullable: true,
           properties: {
@@ -70,7 +70,7 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
             },
           },
         },
-        integer: {
+        [PrimitiveTypeKind.Integer]: {
           type: 'object',
           nullable: true,
           properties: {
@@ -97,7 +97,6 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
           },
         },
       },
-      required: ['general'],
     },
     /**
      * TODO: Refactor to match interface
@@ -105,5 +104,5 @@ export const createFieldSchema: JSONSchemaType<ICreateFieldDTO> = {
      */
     fieldType: { type: 'string', nullable: true },
   },
-  required: ['id', 'key', 'fieldType', 'validationRules'],
+  required: ['id', 'key', 'fieldType'],
 }

--- a/libs/frontend/modules/type/src/use-cases/fields/get-fields/FieldsTable.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/get-fields/FieldsTable.tsx
@@ -22,8 +22,14 @@ interface ValidationRuleTag {
   value: string | number | boolean
 }
 
-const getValidationRuleTagsArray = (validationRules: IValidationRules) => {
+const getValidationRuleTagsArray = (
+  validationRules: Nullish<IValidationRules>,
+) => {
   const rules: Array<ValidationRuleTag> = []
+
+  if (!validationRules) {
+    return rules
+  }
 
   Object.entries(validationRules).forEach(([_, ruleCategory]) => {
     Object.entries(ruleCategory).forEach(([key, value]) => {

--- a/libs/frontend/modules/type/src/use-cases/fields/get-fields/FieldsTable.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/get-fields/FieldsTable.tsx
@@ -1,7 +1,11 @@
 import { DeleteFilled, EditFilled } from '@ant-design/icons'
-import { IInterfaceType, ITypeService } from '@codelab/shared/abstract/core'
+import {
+  IInterfaceType,
+  ITypeService,
+  IValidationRules,
+} from '@codelab/shared/abstract/core'
 import { Nullish } from '@codelab/shared/abstract/types'
-import { Button, Space, Table, TableColumnProps } from 'antd'
+import { Button, Divider, Space, Table, TableColumnProps, Tag } from 'antd'
 import { Observer, observer } from 'mobx-react-lite'
 import React from 'react'
 import tw from 'twin.macro'
@@ -13,12 +17,30 @@ export type FieldsTableProps = {
   hideActions?: boolean
 } & { typeService: ITypeService }
 
+interface ValidationRuleTag {
+  key: string
+  value: string | number | boolean
+}
+
+const getValidationRuleTagsArray = (validationRules: IValidationRules) => {
+  const rules: Array<ValidationRuleTag> = []
+
+  Object.entries(validationRules).forEach(([_, ruleCategory]) => {
+    Object.entries(ruleCategory).forEach(([key, value]) => {
+      rules.push({ key, value: value as any })
+    })
+  })
+
+  return rules
+}
+
 interface CellData {
   id: string
   name: Nullish<string>
   description: Nullish<string>
   key: string
   typeKind?: string
+  validationRules?: Array<ValidationRuleTag>
 }
 
 const headerCellProps = () => ({ style: tw`font-semibold text-gray-900` })
@@ -49,6 +71,33 @@ export const FieldsTable = observer<FieldsTableProps>(
         dataIndex: 'typeKind',
         key: 'typeKind',
         onHeaderCell: headerCellProps,
+      },
+      {
+        title: 'Validation Rules',
+        dataIndex: 'ruleName',
+        key: 'ruleName',
+        onHeaderCell: headerCellProps,
+        render: (_, { validationRules }) =>
+          validationRules &&
+          validationRules.map((rule) => {
+            const color = 'geekblue'
+
+            return typeof rule.value === 'boolean' ? (
+              rule.value && (
+                <Tag color={color} key={rule.key}>
+                  <Space>{rule.key}</Space>
+                </Tag>
+              )
+            ) : (
+              <Tag color={color} key={rule.key}>
+                <Space>
+                  {rule.key}
+                  <Divider type="vertical" />
+                  {rule.value}
+                </Space>
+              </Tag>
+            )
+          }),
       },
       {
         title: 'Action',
@@ -105,6 +154,7 @@ export const FieldsTable = observer<FieldsTableProps>(
       key: f.key,
       typeKind: f.type.maybeCurrent ? f.type.maybeCurrent.kind : '',
       description: f.description || '',
+      validationRules: getValidationRuleTagsArray(f.validationRules),
     }))
 
     return (

--- a/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
@@ -1,8 +1,9 @@
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import { ModalForm } from '@codelab/frontend/view/components'
 import { ITypeService, IUpdateFieldDTO } from '@codelab/shared/abstract/core'
+import { Nullable } from '@codelab/shared/abstract/types'
 import { observer } from 'mobx-react-lite'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import tw from 'twin.macro'
 import { AutoFields } from 'uniforms-antd'
 import { TypeSelect } from '../../../shared'
@@ -12,18 +13,32 @@ export const UpdateFieldModal = observer<{
   typeService: ITypeService
 }>(({ typeService }) => {
   const closeModal = () => typeService.fieldUpdateModal.close()
-  const field = typeService.fieldUpdateModal.field
+  const [model, setModel] = useState<Nullable<IUpdateFieldDTO>>(null)
 
-  if (!field) {
+  useEffect(() => {
+    const field = typeService.fieldUpdateModal.field
+
+    if (!field) {
+      return
+    }
+
+    const validationSchema = JSON.parse(field.validationSchema || '{}')
+
+    setModel({
+      id: field.id,
+      name: field.name,
+      key: field.key,
+      fieldType: field.type.id,
+      description: field.description,
+      validationSchema: { ...validationSchema },
+    })
+  }, [
+    typeService.fieldUpdateModal.field,
+    typeService.fieldUpdateModal.field?.validationSchema,
+  ])
+
+  if (!model) {
     return null
-  }
-
-  const model = {
-    id: field.id,
-    name: field.name,
-    key: field.key,
-    fieldType: field.type.id ?? '',
-    description: field.description,
   }
 
   return (
@@ -36,10 +51,33 @@ export const UpdateFieldModal = observer<{
     >
       <ModalForm.Form<IUpdateFieldDTO>
         model={model}
+        onChange={(key, value) => {
+          setModel((prev) => {
+            // TODO: definetly improve this (works for only 1 level of nesting)
+
+            if (!prev) {
+              return prev
+            }
+
+            if (key.split('.')[0] === 'validationSchema') {
+              const nestedKey = key.split('.')[1]
+
+              return {
+                ...prev,
+                validationSchema: {
+                  ...prev.validationSchema,
+                  [nestedKey]: value,
+                },
+              }
+            }
+
+            return { ...prev, [key]: value }
+          })
+        }}
         onSubmit={(input) =>
           typeService.updateField(
             typeService.fieldUpdateModal?.interface?.id as string,
-            field.key,
+            model.key,
             input,
           )
         }
@@ -56,6 +94,45 @@ export const UpdateFieldModal = observer<{
           name="fieldType"
           types={typeService.typesList}
         />
+
+        <AutoFields fields={['validationSchema.nullable']} />
+
+        {model.fieldType &&
+          typeService.primitiveKind(model.fieldType) === 'String' && (
+            <AutoFields
+              fields={[
+                'validationSchema.minLength',
+                'validationSchema.maxLength',
+                'validationSchema.pattern',
+              ]}
+            />
+          )}
+
+        {model.fieldType &&
+          typeService.primitiveKind(model.fieldType) === 'Integer' && (
+            <AutoFields
+              fields={[
+                'validationSchema.minimum',
+                'validationSchema.maximum',
+                'validationSchema.exclusiveMaximum',
+                'validationSchema.exclusiveMinimum',
+                'validationSchema.multipleOf',
+              ]}
+            />
+          )}
+
+        {model.fieldType &&
+          typeService.primitiveKind(model.fieldType) === 'Float' && (
+            <AutoFields
+              fields={[
+                'validationSchema.minimum',
+                'validationSchema.maximum',
+                'validationSchema.exclusiveMaximum',
+                'validationSchema.exclusiveMinimum',
+                'validationSchema.multipleOf',
+              ]}
+            />
+          )}
       </ModalForm.Form>
     </ModalForm.Modal>
   )

--- a/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
@@ -28,11 +28,11 @@ export const UpdateFieldModal = observer<{
       key: field.key,
       fieldType: field.type.id,
       description: field.description,
-      validationSchema: field.validationSchema,
+      validationRules: field.validationRules,
     })
   }, [
     typeService.fieldUpdateModal.field,
-    typeService.fieldUpdateModal.field?.validationSchema,
+    typeService.fieldUpdateModal.field?.validationRules,
   ])
 
   if (!model) {
@@ -57,18 +57,18 @@ export const UpdateFieldModal = observer<{
 
             const newVal: IUpdateFieldDTO = {
               ...prev,
-              validationSchema: {
+              validationRules: {
                 general: {
-                  ...prev.validationSchema.general,
+                  ...prev.validationRules.general,
                 },
                 string: {
-                  ...prev.validationSchema.string,
+                  ...prev.validationRules.string,
                 },
                 float: {
-                  ...prev.validationSchema.float,
+                  ...prev.validationRules.float,
                 },
                 integer: {
-                  ...prev.validationSchema.integer,
+                  ...prev.validationRules.integer,
                 },
               },
             }
@@ -99,21 +99,21 @@ export const UpdateFieldModal = observer<{
           types={typeService.typesList}
         />
 
-        <AutoFields fields={['validationSchema.general']} />
+        <AutoFields fields={['validationRules.general']} />
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'String' && (
-            <AutoFields fields={['validationSchema.string']} />
+            <AutoFields fields={['validationRules.string']} />
           )}
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'Integer' && (
-            <AutoFields fields={['validationSchema.integer']} />
+            <AutoFields fields={['validationRules.integer']} />
           )}
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'Float' && (
-            <AutoFields fields={['validationSchema.float']} />
+            <AutoFields fields={['validationRules.float']} />
           )}
       </ModalForm.Form>
     </ModalForm.Modal>

--- a/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
+++ b/libs/frontend/modules/type/src/use-cases/fields/update-field/UpdateFieldModal.tsx
@@ -1,5 +1,6 @@
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import { ModalForm } from '@codelab/frontend/view/components'
+import { PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import { ITypeService, IUpdateFieldDTO } from '@codelab/shared/abstract/core'
 import { Nullable } from '@codelab/shared/abstract/types'
 import { observer } from 'mobx-react-lite'
@@ -7,7 +8,11 @@ import React, { useEffect, useState } from 'react'
 import tw from 'twin.macro'
 import { AutoFields } from 'uniforms-antd'
 import { TypeSelect } from '../../../shared'
-import { createFieldSchema, modifyNestedKey } from '../create-field'
+import {
+  createFieldSchema,
+  filterValidationRules,
+  modifyNestedKey,
+} from '../create-field'
 
 export const UpdateFieldModal = observer<{
   typeService: ITypeService
@@ -59,16 +64,16 @@ export const UpdateFieldModal = observer<{
               ...prev,
               validationRules: {
                 general: {
-                  ...prev.validationRules.general,
+                  ...prev?.validationRules?.general,
                 },
-                string: {
-                  ...prev.validationRules.string,
+                [PrimitiveTypeKind.String]: {
+                  ...prev?.validationRules?.String,
                 },
-                float: {
-                  ...prev.validationRules.float,
+                [PrimitiveTypeKind.Float]: {
+                  ...prev?.validationRules?.Float,
                 },
-                integer: {
-                  ...prev.validationRules.integer,
+                [PrimitiveTypeKind.Integer]: {
+                  ...prev?.validationRules?.Integer,
                 },
               },
             }
@@ -82,7 +87,13 @@ export const UpdateFieldModal = observer<{
           typeService.updateField(
             typeService.fieldUpdateModal?.interface?.id as string,
             model.key,
-            input,
+            {
+              ...input,
+              validationRules: filterValidationRules(
+                input.validationRules,
+                typeService.primitiveKind(input.fieldType),
+              ),
+            },
           )
         }
         onSubmitError={createNotificationHandler({
@@ -103,17 +114,17 @@ export const UpdateFieldModal = observer<{
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'String' && (
-            <AutoFields fields={['validationRules.string']} />
+            <AutoFields fields={['validationRules.String']} />
           )}
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'Integer' && (
-            <AutoFields fields={['validationRules.integer']} />
+            <AutoFields fields={['validationRules.Integer']} />
           )}
 
         {model.fieldType &&
           typeService.primitiveKind(model.fieldType) === 'Float' && (
-            <AutoFields fields={['validationRules.float']} />
+            <AutoFields fields={['validationRules.Float']} />
           )}
       </ModalForm.Form>
     </ModalForm.Modal>

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -1937,7 +1937,7 @@ export type Field = {
   key: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
-  validationSchema?: Maybe<Scalars["String"]>;
+  validationRules?: Maybe<Scalars["String"]>;
 };
 
 export type OwnedBy = {
@@ -4690,7 +4690,7 @@ export type InterfaceTypeFieldsRelationship = Field & {
   key: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
-  validationSchema?: Maybe<Scalars["String"]>;
+  validationRules?: Maybe<Scalars["String"]>;
 };
 
 export type InterfaceTypesConnection = {
@@ -13839,7 +13839,7 @@ export type FieldCreateInput = {
   id: Scalars["ID"];
   key: Scalars["String"];
   name?: InputMaybe<Scalars["String"]>;
-  validationSchema?: InputMaybe<Scalars["String"]>;
+  validationRules?: InputMaybe<Scalars["String"]>;
 };
 
 export type FieldSort = {
@@ -13847,7 +13847,7 @@ export type FieldSort = {
   key?: InputMaybe<SortDirection>;
   name?: InputMaybe<SortDirection>;
   description?: InputMaybe<SortDirection>;
-  validationSchema?: InputMaybe<SortDirection>;
+  validationRules?: InputMaybe<SortDirection>;
 };
 
 export type FieldUpdateInput = {
@@ -13855,7 +13855,7 @@ export type FieldUpdateInput = {
   key?: InputMaybe<Scalars["String"]>;
   name?: InputMaybe<Scalars["String"]>;
   description?: InputMaybe<Scalars["String"]>;
-  validationSchema?: InputMaybe<Scalars["String"]>;
+  validationRules?: InputMaybe<Scalars["String"]>;
 };
 
 export type FieldWhere = {
@@ -13901,16 +13901,16 @@ export type FieldWhere = {
   description_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   description_ENDS_WITH?: InputMaybe<Scalars["String"]>;
   description_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationSchema?: InputMaybe<Scalars["String"]>;
-  validationSchema_NOT?: InputMaybe<Scalars["String"]>;
-  validationSchema_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationSchema_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  validationSchema_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationSchema_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
-  validationSchema_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationSchema_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
-  validationSchema_ENDS_WITH?: InputMaybe<Scalars["String"]>;
-  validationSchema_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  validationRules?: InputMaybe<Scalars["String"]>;
+  validationRules_NOT?: InputMaybe<Scalars["String"]>;
+  validationRules_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  validationRules_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  validationRules_CONTAINS?: InputMaybe<Scalars["String"]>;
+  validationRules_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  validationRules_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  validationRules_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  validationRules_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  validationRules_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type HookConfigAggregateInput = {

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -1937,6 +1937,7 @@ export type Field = {
   key: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
+  validationSchema?: Maybe<Scalars["String"]>;
 };
 
 export type OwnedBy = {
@@ -4689,6 +4690,7 @@ export type InterfaceTypeFieldsRelationship = Field & {
   key: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   description?: Maybe<Scalars["String"]>;
+  validationSchema?: Maybe<Scalars["String"]>;
 };
 
 export type InterfaceTypesConnection = {
@@ -13837,6 +13839,7 @@ export type FieldCreateInput = {
   id: Scalars["ID"];
   key: Scalars["String"];
   name?: InputMaybe<Scalars["String"]>;
+  validationSchema?: InputMaybe<Scalars["String"]>;
 };
 
 export type FieldSort = {
@@ -13844,6 +13847,7 @@ export type FieldSort = {
   key?: InputMaybe<SortDirection>;
   name?: InputMaybe<SortDirection>;
   description?: InputMaybe<SortDirection>;
+  validationSchema?: InputMaybe<SortDirection>;
 };
 
 export type FieldUpdateInput = {
@@ -13851,6 +13855,7 @@ export type FieldUpdateInput = {
   key?: InputMaybe<Scalars["String"]>;
   name?: InputMaybe<Scalars["String"]>;
   description?: InputMaybe<Scalars["String"]>;
+  validationSchema?: InputMaybe<Scalars["String"]>;
 };
 
 export type FieldWhere = {
@@ -13896,6 +13901,16 @@ export type FieldWhere = {
   description_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
   description_ENDS_WITH?: InputMaybe<Scalars["String"]>;
   description_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  validationSchema?: InputMaybe<Scalars["String"]>;
+  validationSchema_NOT?: InputMaybe<Scalars["String"]>;
+  validationSchema_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  validationSchema_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  validationSchema_CONTAINS?: InputMaybe<Scalars["String"]>;
+  validationSchema_NOT_CONTAINS?: InputMaybe<Scalars["String"]>;
+  validationSchema_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  validationSchema_NOT_STARTS_WITH?: InputMaybe<Scalars["String"]>;
+  validationSchema_ENDS_WITH?: InputMaybe<Scalars["String"]>;
+  validationSchema_NOT_ENDS_WITH?: InputMaybe<Scalars["String"]>;
 };
 
 export type HookConfigAggregateInput = {

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -10045,6 +10045,7 @@ export type Field = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
+  validationSchema?: Maybe<Scalars['String']>
 }
 
 export type FieldCreateInput = {
@@ -10052,6 +10053,7 @@ export type FieldCreateInput = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: InputMaybe<Scalars['String']>
+  validationSchema?: InputMaybe<Scalars['String']>
 }
 
 export type FieldSort = {
@@ -10059,6 +10061,7 @@ export type FieldSort = {
   id?: InputMaybe<SortDirection>
   key?: InputMaybe<SortDirection>
   name?: InputMaybe<SortDirection>
+  validationSchema?: InputMaybe<SortDirection>
 }
 
 export type FieldUpdateInput = {
@@ -10066,6 +10069,7 @@ export type FieldUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   key?: InputMaybe<Scalars['String']>
   name?: InputMaybe<Scalars['String']>
+  validationSchema?: InputMaybe<Scalars['String']>
 }
 
 export type FieldWhere = {
@@ -10111,6 +10115,16 @@ export type FieldWhere = {
   name_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   name_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
+  validationSchema?: InputMaybe<Scalars['String']>
+  validationSchema_CONTAINS?: InputMaybe<Scalars['String']>
+  validationSchema_ENDS_WITH?: InputMaybe<Scalars['String']>
+  validationSchema_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationSchema_NOT?: InputMaybe<Scalars['String']>
+  validationSchema_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  validationSchema_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  validationSchema_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationSchema_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  validationSchema_STARTS_WITH?: InputMaybe<Scalars['String']>
 }
 
 export type Hook = {
@@ -11013,6 +11027,7 @@ export type InterfaceTypeFieldsRelationship = Field & {
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
   node: TypeBase
+  validationSchema?: Maybe<Scalars['String']>
 }
 
 export type InterfaceTypeFieldsUpdateConnectionInput = {
@@ -22601,6 +22616,7 @@ export type FieldFragment = {
   key: string
   name?: string | null
   description?: string | null
+  validationSchema?: string | null
   fieldType:
     | { __typename?: 'ActionType'; id: string }
     | { __typename?: 'AppType'; id: string }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -10045,7 +10045,7 @@ export type Field = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
-  validationSchema?: Maybe<Scalars['String']>
+  validationRules?: Maybe<Scalars['String']>
 }
 
 export type FieldCreateInput = {
@@ -10053,7 +10053,7 @@ export type FieldCreateInput = {
   id: Scalars['ID']
   key: Scalars['String']
   name?: InputMaybe<Scalars['String']>
-  validationSchema?: InputMaybe<Scalars['String']>
+  validationRules?: InputMaybe<Scalars['String']>
 }
 
 export type FieldSort = {
@@ -10061,7 +10061,7 @@ export type FieldSort = {
   id?: InputMaybe<SortDirection>
   key?: InputMaybe<SortDirection>
   name?: InputMaybe<SortDirection>
-  validationSchema?: InputMaybe<SortDirection>
+  validationRules?: InputMaybe<SortDirection>
 }
 
 export type FieldUpdateInput = {
@@ -10069,7 +10069,7 @@ export type FieldUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   key?: InputMaybe<Scalars['String']>
   name?: InputMaybe<Scalars['String']>
-  validationSchema?: InputMaybe<Scalars['String']>
+  validationRules?: InputMaybe<Scalars['String']>
 }
 
 export type FieldWhere = {
@@ -10115,16 +10115,16 @@ export type FieldWhere = {
   name_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   name_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
-  validationSchema?: InputMaybe<Scalars['String']>
-  validationSchema_CONTAINS?: InputMaybe<Scalars['String']>
-  validationSchema_ENDS_WITH?: InputMaybe<Scalars['String']>
-  validationSchema_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  validationSchema_NOT?: InputMaybe<Scalars['String']>
-  validationSchema_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  validationSchema_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  validationSchema_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
-  validationSchema_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  validationSchema_STARTS_WITH?: InputMaybe<Scalars['String']>
+  validationRules?: InputMaybe<Scalars['String']>
+  validationRules_CONTAINS?: InputMaybe<Scalars['String']>
+  validationRules_ENDS_WITH?: InputMaybe<Scalars['String']>
+  validationRules_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationRules_NOT?: InputMaybe<Scalars['String']>
+  validationRules_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  validationRules_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  validationRules_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationRules_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  validationRules_STARTS_WITH?: InputMaybe<Scalars['String']>
 }
 
 export type Hook = {
@@ -11027,7 +11027,7 @@ export type InterfaceTypeFieldsRelationship = Field & {
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
   node: TypeBase
-  validationSchema?: Maybe<Scalars['String']>
+  validationRules?: Maybe<Scalars['String']>
 }
 
 export type InterfaceTypeFieldsUpdateConnectionInput = {
@@ -22616,7 +22616,7 @@ export type FieldFragment = {
   key: string
   name?: string | null
   description?: string | null
-  validationSchema?: string | null
+  validationRules?: string | null
   fieldType:
     | { __typename?: 'ActionType'; id: string }
     | { __typename?: 'AppType'; id: string }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -4,17 +4,35 @@ import { IField, IFieldRef } from './field'
 import { FieldFragment } from './fragments'
 import { IInterfaceTypeRef } from './types'
 
-interface ValidationRule {
-  name: string
-  value: number
+interface generalValidationRules {
+  nullable?: Nullish<boolean>
 }
+
+interface StringValidationRules {
+  minLength?: Nullish<number>
+  maxLength?: Nullish<number>
+  pattern?: Nullish<string>
+}
+
+interface IntegerValidationRules {
+  maximum?: Nullish<number>
+  minimum?: Nullish<number>
+  exclusiveMaximum?: Nullish<number>
+  exclusiveMinimum?: Nullish<number>
+  multipleOf?: Nullish<number>
+}
+
+type FloatValidationRules = IntegerValidationRules
 
 export interface ICreateFieldDTO {
   id: IFieldRef
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
-  rules?: Nullish<Array<ValidationRule>>
+  generalValidationRules?: Nullish<generalValidationRules>
+  stringValidationRules?: Nullish<StringValidationRules>
+  integerValidationRules?: Nullish<IntegerValidationRules>
+  floatValidationRules?: Nullish<FloatValidationRules>
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -1,4 +1,4 @@
-import { OGM_TYPES } from '@codelab/shared/abstract/codegen'
+import { OGM_TYPES, PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import { Nullish } from '@codelab/shared/abstract/types'
 import { IField, IFieldRef } from './field'
 import { FieldFragment } from './fragments'
@@ -23,7 +23,7 @@ export enum NumberValidationRules {
 }
 
 export interface IGeneralValidationRules {
-  [GeneralValidationRules.Nullable]: boolean
+  [GeneralValidationRules.Nullable]?: Nullish<boolean>
 }
 
 export interface IStringValidationRules {
@@ -41,10 +41,10 @@ export interface INumberValidationRules {
 }
 
 export interface IValidationRules {
-  general: IGeneralValidationRules
-  string?: Nullish<IStringValidationRules>
-  float?: Nullish<INumberValidationRules>
-  integer?: Nullish<INumberValidationRules>
+  general?: Nullish<IGeneralValidationRules>
+  [PrimitiveTypeKind.String]?: Nullish<IStringValidationRules>
+  [PrimitiveTypeKind.Float]?: Nullish<INumberValidationRules>
+  [PrimitiveTypeKind.Integer]?: Nullish<INumberValidationRules>
 }
 
 export interface ICreateFieldDTO {
@@ -52,7 +52,7 @@ export interface ICreateFieldDTO {
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
-  validationRules: IValidationRules
+  validationRules?: Nullish<IValidationRules>
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -4,11 +4,17 @@ import { IField, IFieldRef } from './field'
 import { FieldFragment } from './fragments'
 import { IInterfaceTypeRef } from './types'
 
+interface ValidationRule {
+  name: string
+  value: string
+}
+
 export interface ICreateFieldDTO {
   id: IFieldRef
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
+  rules?: Nullish<Array<ValidationRule>>
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -40,7 +40,7 @@ export interface INumberValidationRules {
   [NumberValidationRules.MultipleOf]?: Nullish<number>
 }
 
-export interface IValidationSchema {
+export interface IValidationRules {
   general: IGeneralValidationRules
   string?: Nullish<IStringValidationRules>
   float?: Nullish<INumberValidationRules>
@@ -52,7 +52,7 @@ export interface ICreateFieldDTO {
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
-  validationSchema: IValidationSchema
+  validationRules: IValidationRules
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -4,17 +4,14 @@ import { IField, IFieldRef } from './field'
 import { FieldFragment } from './fragments'
 import { IInterfaceTypeRef } from './types'
 
-interface generalValidationRules {
+interface validationSchema {
+  // General validation rules
   nullable?: Nullish<boolean>
-}
-
-interface StringValidationRules {
+  // String validation rules
   minLength?: Nullish<number>
   maxLength?: Nullish<number>
   pattern?: Nullish<string>
-}
-
-interface IntegerValidationRules {
+  // Number validation rules
   maximum?: Nullish<number>
   minimum?: Nullish<number>
   exclusiveMaximum?: Nullish<number>
@@ -22,17 +19,12 @@ interface IntegerValidationRules {
   multipleOf?: Nullish<number>
 }
 
-type FloatValidationRules = IntegerValidationRules
-
 export interface ICreateFieldDTO {
   id: IFieldRef
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
-  generalValidationRules?: Nullish<generalValidationRules>
-  stringValidationRules?: Nullish<StringValidationRules>
-  integerValidationRules?: Nullish<IntegerValidationRules>
-  floatValidationRules?: Nullish<FloatValidationRules>
+  validationSchema?: Nullish<validationSchema>
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -4,19 +4,47 @@ import { IField, IFieldRef } from './field'
 import { FieldFragment } from './fragments'
 import { IInterfaceTypeRef } from './types'
 
-interface validationSchema {
-  // General validation rules
-  nullable?: Nullish<boolean>
-  // String validation rules
-  minLength?: Nullish<number>
-  maxLength?: Nullish<number>
-  pattern?: Nullish<string>
-  // Number validation rules
-  maximum?: Nullish<number>
-  minimum?: Nullish<number>
-  exclusiveMaximum?: Nullish<number>
-  exclusiveMinimum?: Nullish<number>
-  multipleOf?: Nullish<number>
+export enum GeneralValidationRules {
+  Nullable = 'nullable',
+}
+
+export enum StringValidationRules {
+  MinLength = 'minLength',
+  MaxLength = 'maxLength',
+  Pattern = 'pattern',
+}
+
+export enum NumberValidationRules {
+  Maximum = 'maximum',
+  Minimum = 'minimum',
+  ExclusiveMaximum = 'exclusiveMaximum',
+  ExclusiveMinimum = 'exclusiveMinimum',
+  MultipleOf = 'multipleOf',
+}
+
+export interface IGeneralValidationRules {
+  [GeneralValidationRules.Nullable]: boolean
+}
+
+export interface IStringValidationRules {
+  [StringValidationRules.MinLength]?: Nullish<number>
+  [StringValidationRules.MaxLength]?: Nullish<number>
+  [StringValidationRules.Pattern]?: Nullish<string>
+}
+
+export interface INumberValidationRules {
+  [NumberValidationRules.Minimum]?: Nullish<number>
+  [NumberValidationRules.Maximum]?: Nullish<number>
+  [NumberValidationRules.ExclusiveMinimum]?: Nullish<number>
+  [NumberValidationRules.ExclusiveMaximum]?: Nullish<number>
+  [NumberValidationRules.MultipleOf]?: Nullish<number>
+}
+
+export interface IValidationSchema {
+  general: IGeneralValidationRules
+  string?: Nullish<IStringValidationRules>
+  float?: Nullish<INumberValidationRules>
+  integer?: Nullish<INumberValidationRules>
 }
 
 export interface ICreateFieldDTO {
@@ -24,7 +52,7 @@ export interface ICreateFieldDTO {
   key: string
   name?: Nullish<string>
   description?: Nullish<string>
-  validationSchema?: Nullish<validationSchema>
+  validationSchema: IValidationSchema
   // Type of field specified by an interface id
   fieldType: IInterfaceTypeRef
 }

--- a/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field.dto.interface.ts
@@ -6,7 +6,7 @@ import { IInterfaceTypeRef } from './types'
 
 interface ValidationRule {
   name: string
-  value: string
+  value: number
 }
 
 export interface ICreateFieldDTO {

--- a/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
@@ -14,7 +14,7 @@ export interface IField<T extends IAnyType = IAnyType>
   description: Nullish<string>
   key: string
   type: Ref<T>
-  validationRules: IValidationRules
+  validationRules: Nullish<IValidationRules>
 }
 
 export type IFieldRef = string

--- a/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
@@ -1,7 +1,7 @@
 import { Nullish } from '@codelab/shared/abstract/types'
 import { Ref } from 'mobx-keystone'
 import { ICacheService } from '../../../service'
-import { IFieldProps, IValidationSchema } from '../field.dto.interface'
+import { IFieldProps, IValidationRules } from '../field.dto.interface'
 import type { IAnyType } from '../types'
 
 export interface IField<T extends IAnyType = IAnyType>
@@ -14,7 +14,7 @@ export interface IField<T extends IAnyType = IAnyType>
   description: Nullish<string>
   key: string
   type: Ref<T>
-  validationSchema: IValidationSchema
+  validationRules: IValidationRules
 }
 
 export type IFieldRef = string

--- a/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
@@ -1,7 +1,7 @@
 import { Nullish } from '@codelab/shared/abstract/types'
 import { Ref } from 'mobx-keystone'
 import { ICacheService } from '../../../service'
-import { IFieldProps } from '../field.dto.interface'
+import { IFieldProps, IValidationSchema } from '../field.dto.interface'
 import type { IAnyType } from '../types'
 
 export interface IField<T extends IAnyType = IAnyType>
@@ -14,7 +14,7 @@ export interface IField<T extends IAnyType = IAnyType>
   description: Nullish<string>
   key: string
   type: Ref<T>
-  validationSchema: Nullish<string>
+  validationSchema: IValidationSchema
 }
 
 export type IFieldRef = string

--- a/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/field/field.interface.ts
@@ -14,6 +14,7 @@ export interface IField<T extends IAnyType = IAnyType>
   description: Nullish<string>
   key: string
   type: Ref<T>
+  validationSchema: Nullish<string>
 }
 
 export type IFieldRef = string

--- a/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql
+++ b/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql
@@ -3,6 +3,7 @@ fragment Field on InterfaceTypeFieldsRelationship {
   key
   name
   description
+  validationSchema
   fieldType: node {
     ... on TypeBase {
       id

--- a/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql
+++ b/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql
@@ -3,7 +3,7 @@ fragment Field on InterfaceTypeFieldsRelationship {
   key
   name
   description
-  validationSchema
+  validationRules
   fieldType: node {
     ... on TypeBase {
       id

--- a/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
+++ b/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
@@ -8,7 +8,7 @@ export type FieldFragment = {
   key: string
   name?: string | null
   description?: string | null
-  validationSchema?: string | null
+  validationRules?: string | null
   fieldType:
     | { id: string }
     | { id: string }
@@ -31,7 +31,7 @@ export const FieldFragmentDoc = gql`
     key
     name
     description
-    validationSchema
+    validationRules
     fieldType: node {
       ... on TypeBase {
         id

--- a/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
+++ b/libs/shared/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
@@ -8,6 +8,7 @@ export type FieldFragment = {
   key: string
   name?: string | null
   description?: string | null
+  validationSchema?: string | null
   fieldType:
     | { id: string }
     | { id: string }
@@ -30,6 +31,7 @@ export const FieldFragmentDoc = gql`
     key
     name
     description
+    validationSchema
     fieldType: node {
       ... on TypeBase {
         id

--- a/libs/shared/abstract/core/src/domain/type/type.service.interface.ts
+++ b/libs/shared/abstract/core/src/domain/type/type.service.interface.ts
@@ -1,5 +1,9 @@
-import { GetTypesQuery, TypeBaseWhere } from '@codelab/shared/abstract/codegen'
-import { Maybe } from '@codelab/shared/abstract/types'
+import {
+  GetTypesQuery,
+  PrimitiveTypeKind,
+  TypeBaseWhere,
+} from '@codelab/shared/abstract/codegen'
+import { Maybe, Nullable } from '@codelab/shared/abstract/types'
 import { ArraySet, ObjectMap, Ref } from 'mobx-keystone'
 import {
   ICRUDModalService,
@@ -29,6 +33,7 @@ export interface ITypeService
   getInterfaceAndDescendants(id: IInterfaceTypeRef): Promise<IInterfaceType>
   types: ObjectMap<IAnyType>
   type(id: string): Maybe<IAnyType>
+  primitiveKind(id: string): Nullable<PrimitiveTypeKind>
   typesList: Array<IAnyType>
   fieldCreateModal: IEntityModalService<
     Ref<IInterfaceType>,

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -9610,6 +9610,7 @@ interface Field {
   id: ID!
   key: String!
   name: String
+  validationSchema: String
 }
 
 input FieldCreateInput {
@@ -9617,6 +9618,7 @@ input FieldCreateInput {
   id: ID!
   key: String!
   name: String
+  validationSchema: String
 }
 
 input FieldSort {
@@ -9624,6 +9626,7 @@ input FieldSort {
   id: SortDirection
   key: SortDirection
   name: SortDirection
+  validationSchema: SortDirection
 }
 
 input FieldUpdateInput {
@@ -9631,6 +9634,7 @@ input FieldUpdateInput {
   id: ID
   key: String
   name: String
+  validationSchema: String
 }
 
 input FieldWhere {
@@ -9676,6 +9680,16 @@ input FieldWhere {
   name_NOT_IN: [String]
   name_NOT_STARTS_WITH: String
   name_STARTS_WITH: String
+  validationSchema: String
+  validationSchema_CONTAINS: String
+  validationSchema_ENDS_WITH: String
+  validationSchema_IN: [String]
+  validationSchema_NOT: String
+  validationSchema_NOT_CONTAINS: String
+  validationSchema_NOT_ENDS_WITH: String
+  validationSchema_NOT_IN: [String]
+  validationSchema_NOT_STARTS_WITH: String
+  validationSchema_STARTS_WITH: String
 }
 
 type Hook {
@@ -10517,6 +10531,7 @@ type InterfaceTypeFieldsRelationship implements Field {
   key: String!
   name: String
   node: TypeBase!
+  validationSchema: String
 }
 
 input InterfaceTypeFieldsUpdateConnectionInput {

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -9610,7 +9610,7 @@ interface Field {
   id: ID!
   key: String!
   name: String
-  validationSchema: String
+  validationRules: String
 }
 
 input FieldCreateInput {
@@ -9618,7 +9618,7 @@ input FieldCreateInput {
   id: ID!
   key: String!
   name: String
-  validationSchema: String
+  validationRules: String
 }
 
 input FieldSort {
@@ -9626,7 +9626,7 @@ input FieldSort {
   id: SortDirection
   key: SortDirection
   name: SortDirection
-  validationSchema: SortDirection
+  validationRules: SortDirection
 }
 
 input FieldUpdateInput {
@@ -9634,7 +9634,7 @@ input FieldUpdateInput {
   id: ID
   key: String
   name: String
-  validationSchema: String
+  validationRules: String
 }
 
 input FieldWhere {
@@ -9680,16 +9680,16 @@ input FieldWhere {
   name_NOT_IN: [String]
   name_NOT_STARTS_WITH: String
   name_STARTS_WITH: String
-  validationSchema: String
-  validationSchema_CONTAINS: String
-  validationSchema_ENDS_WITH: String
-  validationSchema_IN: [String]
-  validationSchema_NOT: String
-  validationSchema_NOT_CONTAINS: String
-  validationSchema_NOT_ENDS_WITH: String
-  validationSchema_NOT_IN: [String]
-  validationSchema_NOT_STARTS_WITH: String
-  validationSchema_STARTS_WITH: String
+  validationRules: String
+  validationRules_CONTAINS: String
+  validationRules_ENDS_WITH: String
+  validationRules_IN: [String]
+  validationRules_NOT: String
+  validationRules_NOT_CONTAINS: String
+  validationRules_NOT_ENDS_WITH: String
+  validationRules_NOT_IN: [String]
+  validationRules_NOT_STARTS_WITH: String
+  validationRules_STARTS_WITH: String
 }
 
 type Hook {
@@ -10531,7 +10531,7 @@ type InterfaceTypeFieldsRelationship implements Field {
   key: String!
   name: String
   node: TypeBase!
-  validationSchema: String
+  validationRules: String
 }
 
 input InterfaceTypeFieldsUpdateConnectionInput {


### PR DESCRIPTION
## Description

This PR introduces the validation module for InterfaceType Fields as discussed in #1760. The only difference is that the validation will be stored in the DB as a stringified JSON because Neo4J doesn't support nested data on relationships.

TODO:

- [x] Update Field's GraphQL and DB schema to accommodate validation rules.
- [x] Set the value of validationSchema when creating a new field.
- [x] Use the value of validationSchema to validate values set to fields (currently `CodeMirrorField.tsx`)
- [x] Auto suggest validation rules based on field type and accept the correct values type per validation rule. for example `minLength` accepts `number` value, but `pattern` accepts `string`.
- [x] Allow changing validationSchema in UpdateFieldModal.
- [x] ~Use validation in other `Field.tsx` fields.~ Integrate with `TypeSchemaFactory`.
- [x] ~Visualize errors when a field's value is invalid (currently we just prevent it from updating DB).~ Automatically done thanks to the transition to uniforms.
- [x] Visualize current set validation rules in fields table of an interface
- [x] refactor and fix failing tests

## Demo


https://user-images.githubusercontent.com/51242349/192883113-2c77682e-20ca-43e5-bc93-97738befb23a.mp4


## Related Issue
Fixes #1760 