### PR TITLE
fix: autosave typo

### DIFF
--- a/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/modules/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -78,7 +78,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
           <Row gutter={[0, 16]}>
             <Col span={24}>
               <PropsForm
-                autoSave
+                autosave
                 context={{ autocomplete, builderState, actionList }}
                 interfaceType={interfaceType}
                 key={element.id}

--- a/libs/frontend/modules/type/src/props-form/PropsForm.tsx
+++ b/libs/frontend/modules/type/src/props-form/PropsForm.tsx
@@ -23,7 +23,6 @@ import { PropsFields } from './PropsFields'
 
 export interface PropsFormProps extends SubmitRef {
   interfaceType?: IInterfaceType
-  autoSave?: boolean
   model?: IPropData
   onSubmit: (values: IPropData) => Promise<IPropData | void>
   autosave?: boolean


### PR DESCRIPTION
## Description

This also fixes a bug causing element prop changes from being saved

## Related Issue(s)
