### PR TITLE
feat: resolver get base types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
-    - swissknife/wait_for_job:
-        job-name: install-and-build-workspace,lint,unit,e2e,codegen
+    #    - swissknife/wait_for_job:
+    #        job-name: install-and-build-workspace,lint,unit,e2e,codegen
     - slack/notify:
         event: fail
         channel: $SLACK_CHANNEL_UPDATE
@@ -351,6 +351,7 @@ jobs:
 workflows:
   app-pr:
     jobs:
+      # This doesn't actually have access to Slack errors, must be at end of step
       #      - notify-failure:
       #          <<: *filters-pr
       #          context: CI
@@ -358,14 +359,14 @@ workflows:
       - install-and-build-workspace:
           <<:
             - *filters-pr
-            - *slack-fail-post-step
+          #            - *slack-fail-post-step
           # Can't build with machine image, causes build issues
           e: docker-node
           context: CI
       - lint:
           <<:
             - *filters-pr
-            - *slack-fail-post-step
+          #            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -373,7 +374,7 @@ workflows:
       - codegen:
           <<:
             - *filters-pr
-            - *slack-fail-post-step
+          #            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -381,7 +382,7 @@ workflows:
       - unit:
           <<:
             - *filters-pr
-            - *slack-fail-post-step
+          #            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -389,7 +390,7 @@ workflows:
       - e2e:
           <<:
             - *filters-pr
-            - *slack-fail-post-step
+          #            - *slack-fail-post-step
           e: docker-node-neo4j
           context: CI
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
     steps:
       - setup-workspace
       - run:
-          name: 'Run Lint on Workspace'
+          name: 'Run Lint on Repository'
           command: yarn cli tasks lint --env ci
       - run:
           name: 'GraphQL Codegen'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,10 +329,6 @@ jobs:
     steps:
       - swissknife/wait_for_job:
           job-name: install-and-build-workspace,lint,unit,e2e
-      #          job-name: ^(install-and-build-workspace|lint|unit|e2e)$
-      # - swissknife/wait_for_workflow:
-      #     workflow-name: ^(app-pr|app)$
-      #     max-wait-time: '1500'
       - slack/notify:
           event: fail
           channel: $SLACK_CHANNEL_UPDATE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,15 @@
 # Parallel Slack notification https://github.com/CircleCI-Public/slack-orb/issues/305
 # https://support.circleci.com/hc/en-us/articles/360047082992-Send-slack-notification-at-end-of-workflow
 
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - swissknife/wait_for_job:
+        job-name: install-and-build-workspace,lint,unit,e2e,codegen
+    - slack/notify:
+        event: fail
+        channel: $SLACK_CHANNEL_UPDATE
+        template: basic_fail_1
+
 filters-pr: &filters-pr
   filters:
     branches:
@@ -342,19 +351,21 @@ jobs:
 workflows:
   app-pr:
     jobs:
-      - notify-failure:
-          <<: *filters-pr
-          context: CI
-          e: docker-node
+      #      - notify-failure:
+      #          <<: *filters-pr
+      #          context: CI
+      #          e: docker-node
       - install-and-build-workspace:
           <<:
             - *filters-pr
+            - *slack-fail-post-step
           # Can't build with machine image, causes build issues
           e: docker-node
           context: CI
       - lint:
           <<:
             - *filters-pr
+            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -362,6 +373,7 @@ workflows:
       - codegen:
           <<:
             - *filters-pr
+            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -369,6 +381,7 @@ workflows:
       - unit:
           <<:
             - *filters-pr
+            - *slack-fail-post-step
           e: docker-node
           context: CI
           requires:
@@ -376,6 +389,7 @@ workflows:
       - e2e:
           <<:
             - *filters-pr
+            - *slack-fail-post-step
           e: docker-node-neo4j
           context: CI
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,11 +186,16 @@ jobs:
           name: 'Run Lint on Repository'
           command: yarn cli tasks lint --env ci
       - run:
-          name: 'GraphQL Codegen'
-          command: yarn cli tasks codegen --env ci
-      - run:
           name: 'Commitlint'
           command: yarn cli tasks commitlint --env ci
+
+  codegen:
+    <<: *executor-params
+    steps:
+      - setup-workspace
+      - run:
+          name: 'GraphQL Codegen'
+          command: yarn cli tasks codegen --env ci
 
   unit:
     <<: *executor-params
@@ -328,7 +333,7 @@ jobs:
     <<: *executor-params
     steps:
       - swissknife/wait_for_job:
-          job-name: install-and-build-workspace,lint,unit,e2e
+          job-name: install-and-build-workspace,lint,unit,e2e,codegen
       - slack/notify:
           event: fail
           channel: $SLACK_CHANNEL_UPDATE
@@ -344,14 +349,19 @@ workflows:
       - install-and-build-workspace:
           <<:
             - *filters-pr
-            # - *slack-post-step
           # Can't build with machine image, causes build issues
           e: docker-node
           context: CI
       - lint:
           <<:
             - *filters-pr
-            # - *slack-post-step
+          e: docker-node
+          context: CI
+          requires:
+            - install-and-build-workspace
+      - codegen:
+          <<:
+            - *filters-pr
           e: docker-node
           context: CI
           requires:
@@ -359,7 +369,6 @@ workflows:
       - unit:
           <<:
             - *filters-pr
-            # - *slack-post-step
           e: docker-node
           context: CI
           requires:
@@ -367,7 +376,6 @@ workflows:
       - e2e:
           <<:
             - *filters-pr
-            # - *slack-post-step
           e: docker-node-neo4j
           context: CI
           requires:
@@ -378,6 +386,7 @@ workflows:
           e: docker-node
           requires:
             - lint
+            - codegen
             - unit
             - e2e
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -281,8 +281,6 @@
         // Custom import rules
         //
         "import/newline-after-import": "error",
-        "import/no-unresolved": "error",
-        "import/named": "error",
         "import/first": "error",
         // SUPER SLOW!
         "import/no-cycle": "off",
@@ -445,6 +443,13 @@
       }
     },
     {
+      "files": ["*.spec.ts", "*.spec.tsx"],
+      "rules": {
+        "import/no-unresolved": "error",
+        "import/named": "error"
+      }
+    },
+    {
       "files": ["*.ts", "*.tsx"],
       "extends": [
         "plugin:@nrwl/nx/typescript",
@@ -495,15 +500,6 @@
         "react/jsx-props-no-spreading": "off"
       }
     },
-    //    {
-    //      "files": ["*.spec.ts"],
-    //      "extends": ["plugin:import/recommended"],
-    //      "rules": {}
-    //    },
-    //    {
-    //      "files": ["*.jsx", "*.tsx"],
-    //      "extends": ["plugin:react-hooks/recommended"]
-    //    },
     {
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nrwl/nx/javascript"],

--- a/apps/builder-e2e/.eslintrc.json
+++ b/apps/builder-e2e/.eslintrc.json
@@ -9,6 +9,8 @@
         "project": ["apps/builder-e2e/tsconfig(.*)?.json"]
       },
       "rules": {
+        "import/no-unresolved": "error",
+        "import/named": "error",
         "jest/valid-expect": "off",
         "@nrwl/nx/enforce-module-boundaries": "off",
         "@typescript-eslint/no-explicit-any": "off"

--- a/apps/builder-e2e/src/support/database/type.ts
+++ b/apps/builder-e2e/src/support/database/type.ts
@@ -1,5 +1,5 @@
 import { ITypeDTO } from '@codelab/frontend/abstract/core'
-import { TypeBaseCreateInput } from '@codelab/shared/abstract/codegen'
+import { BaseTypeCreateInput } from '@codelab/shared/abstract/codegen'
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import { DocumentNode, print } from 'graphql'
 import {
@@ -34,7 +34,7 @@ const createTypeQuery: { [key in ITypeKind]: DocumentNode } = {
   [ITypeKind.ActionType]: CreateActionTypesDocument,
 }
 
-export const createType = (input: TypeBaseCreateInput, typeKind: ITypeKind) =>
+export const createType = (input: BaseTypeCreateInput, typeKind: ITypeKind) =>
   cy
     .graphqlRequest({
       query: print(createTypeQuery[typeKind]),

--- a/apps/builder/pages/api/graphql.ts
+++ b/apps/builder/pages/api/graphql.ts
@@ -1,7 +1,10 @@
 /**
  * This file is under `api` code so can import backend code
  */
-import { NextApiRequest } from '@codelab/backend/abstract/types'
+import {
+  GraphQLRequestContext,
+  NextApiRequest,
+} from '@codelab/backend/abstract/types'
 import { resolvers } from '@codelab/backend/graphql'
 import {
   getDriver,
@@ -27,7 +30,7 @@ const startServer = neoSchema
   .then(async (schema) => {
     apolloServer = new ApolloServer({
       schema,
-      context: ({ req }: { req: NextApiRequest }) => {
+      context: ({ req }: { req: NextApiRequest }): GraphQLRequestContext => {
         const user = req.user
 
         return {

--- a/apps/cli/src/commands/tasks/tasks.command.ts
+++ b/apps/cli/src/commands/tasks/tasks.command.ts
@@ -249,7 +249,7 @@ export const tasksCommand: CommandModule<unknown, unknown> = {
           }
 
           if (env === Env.CI) {
-            execCommand(`npx nx affected:lint`)
+            execCommand(`npx nx affected:lint --parallel=6`)
             execCommand(`npx prettier --check ./**/*.{graphql,yaml,json}`)
             execCommand(
               `yarn madge --circular apps libs --extensions ts,tsx,js,jsx`,

--- a/codegen.yml
+++ b/codegen.yml
@@ -25,22 +25,22 @@ generates:
       - schema-ast
 
   # Generate Typescript types to be imported by other generators
-  #  libs/shared/abstract/codegen/src/types.api.graphql.gen.ts:
-  #    documents:
-  #      - '{apps,libs}/**/*.graphql'
-  #    plugins:
-  #      - typescript
-  #      # We want to generate another copy in `shared` folder so our interfaces can access this
-  #      #
-  #      # This will be a duplicate copy of operation types from the `near-operation-file` plugin
-  #      - typescript-operations
-  #    #      - typed-document-node
-  #    config:
-  #      #      constEnums: true
-  #      inlineFragmentTypes: combine
-  #      namingConvention:
-  #        enumValues: keep
-  #  #        dedupeFragments: true
+  libs/shared/abstract/codegen/src/types.api.graphql.gen.ts:
+    documents:
+      - '{apps,libs}/**/*.graphql'
+    plugins:
+      - typescript
+      # We want to generate another copy in `shared` folder so our interfaces can access this
+      #
+      # This will be a duplicate copy of operation types from the `near-operation-file` plugin
+      - typescript-operations
+    #      - typed-document-node
+    config:
+      #      constEnums: true
+      inlineFragmentTypes: combine
+      namingConvention:
+        enumValues: keep
+  #        dedupeFragments: true
 
   # This somehow generates for web-e2e as well, even if ./libs
   ./:

--- a/codegen.yml
+++ b/codegen.yml
@@ -31,7 +31,6 @@ generates:
     plugins:
       - typescript
       # We want to generate another copy in `shared` folder so our interfaces can access this
-      #
       # This will be a duplicate copy of operation types from the `near-operation-file` plugin
       - typescript-operations
     #      - typed-document-node

--- a/libs/backend/abstract/core/src/seed/ant-design-api.ts
+++ b/libs/backend/abstract/core/src/seed/ant-design-api.ts
@@ -6,6 +6,6 @@ export interface ExistingData {
   tags: { [tagName: string]: OGM_TYPES.Tag }
   fields: { [fieldCompositeKey: string]: OGM_TYPES.Field }
   api: { [interfaceTypeName: string]: OGM_TYPES.InterfaceType }
-  types: { [typeName: string]: OGM_TYPES.TypeBase }
-  typesById: { [typeName: string]: OGM_TYPES.TypeBase }
+  types: { [typeName: string]: OGM_TYPES.IBaseType }
+  typesById: { [typeName: string]: OGM_TYPES.IBaseType }
 }

--- a/libs/backend/abstract/core/src/type.interface.ts
+++ b/libs/backend/abstract/core/src/type.interface.ts
@@ -25,7 +25,7 @@ export type IInterfaceTypeExport = Pick<
   Required<Pick<OGM_TYPES.InterfaceType, '__typename'>> & {
     // We don't want meta data here
     fieldsConnection: Pick<OGM_TYPES.InterfaceTypeFieldsConnection, 'edges'>
-    ownerConnection: Pick<OGM_TYPES.TypeBaseOwnerConnection, 'edges'>
+    ownerConnection: Pick<OGM_TYPES.IBaseTypeOwnerConnection, 'edges'>
   }
 
 export type IEnumTypeExport = Pick<

--- a/libs/backend/application/src/repositories/type/index.ts
+++ b/libs/backend/application/src/repositories/type/index.ts
@@ -1,1 +1,2 @@
 export * from './field/field.repo'
+export * from './type.repo'

--- a/libs/backend/application/src/repositories/type/type.repo.ts
+++ b/libs/backend/application/src/repositories/type/type.repo.ts
@@ -1,11 +1,9 @@
 import { getBaseTypes } from '@codelab/backend/infra/adapter/neo4j'
 import {
-  BaseType,
   GetBaseTypesReturn,
   QueryBaseTypesArgs,
 } from '@codelab/shared/abstract/codegen'
-import { int, Record, Transaction } from 'neo4j-driver'
-import { GetBaseTypesRecord } from './types'
+import { int, Transaction } from 'neo4j-driver'
 
 export const typeRepository = {
   baseTypes: async (
@@ -23,32 +21,15 @@ export const typeRepository = {
     const totalCountRecord = getTypesRecords[0]?.get('totalCount')
     const totalCount = totalCountRecord ? int(totalCountRecord).toNumber() : 0
 
-    const withOwner = (
-      data: BaseType,
-      record: Record<GetBaseTypesRecord>,
-    ): BaseType => {
+    const items = getTypesRecords.map((record) => {
+      const type = record.get('type').properties
       const owner = record.get('owner').properties
 
       return {
-        ...data,
-        owner,
-      }
-    }
-
-    const dataMapper = (record: Record<GetBaseTypesRecord>): BaseType => {
-      const type = record.get('type').properties
-
-      return {
         ...type,
+        owner,
         __typename: 'BaseType',
       }
-    }
-
-    const items = getTypesRecords.map((record) => {
-      return withOwner(
-        dataMapper(record as Record<GetBaseTypesRecord>),
-        record as Record<GetBaseTypesRecord>,
-      )
     })
 
     return {

--- a/libs/backend/application/src/repositories/type/type.repo.ts
+++ b/libs/backend/application/src/repositories/type/type.repo.ts
@@ -11,11 +11,12 @@ export const typeRepository = {
     params: QueryBaseTypesArgs,
   ): Promise<GetBaseTypesReturn> => {
     const { options } = params
-    const { limit = 10, offset = 0 } = options || {}
+    const limit = options?.limit ?? 10
+    const offset = options?.offset ?? 0
 
     const { records: getTypesRecords } = await txn.run(getBaseTypes, {
-      limit: int(Number(limit)),
-      skip: int(Number(offset)),
+      limit: int(limit),
+      skip: int(offset),
     })
 
     const totalCountRecord = getTypesRecords[0]?.get('totalCount')

--- a/libs/backend/application/src/repositories/type/type.repo.ts
+++ b/libs/backend/application/src/repositories/type/type.repo.ts
@@ -2,10 +2,9 @@ import {
   countBaseTypes,
   getBaseTypes,
 } from '@codelab/backend/infra/adapter/neo4j'
+import { BaseType, QueryBaseTypesArgs } from '@codelab/shared/abstract/codegen'
 import { int, Record, Transaction } from 'neo4j-driver'
 import { GetBaseTypesRecord } from './types'
-
-type BaseType = any
 
 export const typeRepository = {
   countBaseTypes: async (txn: Transaction, offset = 0): Promise<number> => {
@@ -21,7 +20,7 @@ export const typeRepository = {
 
   baseTypes: async (
     txn: Transaction,
-    params: any,
+    params: QueryBaseTypesArgs,
   ): Promise<Array<BaseType>> => {
     const { options } = params
     const { limit = 10, offset = 0 } = options || {}
@@ -35,11 +34,7 @@ export const typeRepository = {
       data: BaseType,
       record: Record<GetBaseTypesRecord>,
     ): BaseType => {
-      const owner = record.get('owner')?.properties
-
-      if (!owner) {
-        throw new Error('owner not found')
-      }
+      const owner = record.get('owner').properties
 
       return {
         ...data,
@@ -56,7 +51,7 @@ export const typeRepository = {
       }
     }
 
-    const items = getTypesRecords.flatMap((record) => {
+    const items = getTypesRecords.map((record) => {
       return withOwner(
         dataMapper(record as Record<GetBaseTypesRecord>),
         record as Record<GetBaseTypesRecord>,

--- a/libs/backend/application/src/repositories/type/type.repo.ts
+++ b/libs/backend/application/src/repositories/type/type.repo.ts
@@ -1,27 +1,17 @@
+import { getBaseTypes } from '@codelab/backend/infra/adapter/neo4j'
 import {
-  countBaseTypes,
-  getBaseTypes,
-} from '@codelab/backend/infra/adapter/neo4j'
-import { BaseType, QueryBaseTypesArgs } from '@codelab/shared/abstract/codegen'
+  BaseType,
+  GetBaseTypesReturn,
+  QueryBaseTypesArgs,
+} from '@codelab/shared/abstract/codegen'
 import { int, Record, Transaction } from 'neo4j-driver'
 import { GetBaseTypesRecord } from './types'
 
 export const typeRepository = {
-  countBaseTypes: async (txn: Transaction, offset = 0): Promise<number> => {
-    const { records: countTypesRecords } = await txn.run(countBaseTypes, {
-      skip: int(Number(offset)),
-    })
-
-    const totalCountNeo4j = countTypesRecords[0].get('count(type)')
-    const totalCount = int(totalCountNeo4j).toNumber()
-
-    return totalCount
-  },
-
   baseTypes: async (
     txn: Transaction,
     params: QueryBaseTypesArgs,
-  ): Promise<Array<BaseType>> => {
+  ): Promise<GetBaseTypesReturn> => {
     const { options } = params
     const { limit = 10, offset = 0 } = options || {}
 
@@ -29,6 +19,9 @@ export const typeRepository = {
       limit: int(Number(limit)),
       skip: int(Number(offset)),
     })
+
+    const totalCountRecord = getTypesRecords[0]?.get('totalCount')
+    const totalCount = totalCountRecord ? int(totalCountRecord).toNumber() : 0
 
     const withOwner = (
       data: BaseType,
@@ -58,6 +51,9 @@ export const typeRepository = {
       )
     })
 
-    return items
+    return {
+      items,
+      totalCount,
+    }
   },
 }

--- a/libs/backend/application/src/repositories/type/type.repo.ts
+++ b/libs/backend/application/src/repositories/type/type.repo.ts
@@ -1,0 +1,68 @@
+import {
+  countBaseTypes,
+  getBaseTypes,
+} from '@codelab/backend/infra/adapter/neo4j'
+import { int, Record, Transaction } from 'neo4j-driver'
+import { GetBaseTypesRecord } from './types'
+
+type BaseType = any
+
+export const typeRepository = {
+  countBaseTypes: async (txn: Transaction, offset = 0): Promise<number> => {
+    const { records: countTypesRecords } = await txn.run(countBaseTypes, {
+      skip: int(Number(offset)),
+    })
+
+    const totalCountNeo4j = countTypesRecords[0].get('count(type)')
+    const totalCount = int(totalCountNeo4j).toNumber()
+
+    return totalCount
+  },
+
+  baseTypes: async (
+    txn: Transaction,
+    params: any,
+  ): Promise<Array<BaseType>> => {
+    const { options } = params
+    const { limit = 10, offset = 0 } = options || {}
+
+    const { records: getTypesRecords } = await txn.run(getBaseTypes, {
+      limit: int(Number(limit)),
+      skip: int(Number(offset)),
+    })
+
+    const withOwner = (
+      data: BaseType,
+      record: Record<GetBaseTypesRecord>,
+    ): BaseType => {
+      const owner = record.get('owner')?.properties
+
+      if (!owner) {
+        throw new Error('owner not found')
+      }
+
+      return {
+        ...data,
+        owner,
+      }
+    }
+
+    const dataMapper = (record: Record<GetBaseTypesRecord>): BaseType => {
+      const type = record.get('type').properties
+
+      return {
+        ...type,
+        __typename: 'BaseType',
+      }
+    }
+
+    const items = getTypesRecords.flatMap((record) => {
+      return withOwner(
+        dataMapper(record as Record<GetBaseTypesRecord>),
+        record as Record<GetBaseTypesRecord>,
+      )
+    })
+
+    return items
+  },
+}

--- a/libs/backend/application/src/repositories/type/types.ts
+++ b/libs/backend/application/src/repositories/type/types.ts
@@ -1,0 +1,7 @@
+import { BaseType, User } from '@codelab/shared/abstract/codegen'
+import { Integer, Node } from 'neo4j-driver'
+
+export interface GetBaseTypesRecord {
+  types: Node<Integer, BaseType>
+  owner: Node<Integer, User>
+}

--- a/libs/backend/graphql/src/resolvers/type/index.ts
+++ b/libs/backend/graphql/src/resolvers/type/index.ts
@@ -1,9 +1,13 @@
+import { withReadTransactionResolver } from '@codelab/backend/infra/adapter/neo4j'
 import { IResolvers } from '@graphql-tools/utils'
-import { upsertField } from './upsert-field.resolver'
+import { upsertField } from './mutation'
+import { baseTypes } from './query'
 
 export const typeResolver: IResolvers = {
   Mutation: {
     upsertField,
   },
-  Query: {},
+  Query: {
+    baseTypes: withReadTransactionResolver(baseTypes),
+  },
 }

--- a/libs/backend/graphql/src/resolvers/type/mutation/index.ts
+++ b/libs/backend/graphql/src/resolvers/type/mutation/index.ts
@@ -1,0 +1,1 @@
+export * from './upsert-field.resolver'

--- a/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
@@ -1,11 +1,10 @@
-import { GraphQLRequestContext } from '@codelab/backend/abstract/types'
 import { fieldRepository } from '@codelab/backend/application'
 import { MutationUpsertFieldArgs } from '@codelab/shared/abstract/codegen'
 import { IFieldResolver } from '@graphql-tools/utils'
 
 export const upsertField: IFieldResolver<
-  undefined,
-  GraphQLRequestContext,
+  unknown,
+  unknown,
   MutationUpsertFieldArgs
 > = async (_, args) => {
   return fieldRepository.upsertField(args)

--- a/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
@@ -6,6 +6,6 @@ export const upsertField: IFieldResolver<
   unknown,
   unknown,
   MutationUpsertFieldArgs
-> = async (parent, args) => {
+> = async (_, args) => {
   return fieldRepository.upsertField(args)
 }

--- a/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/mutation/upsert-field.resolver.ts
@@ -1,10 +1,11 @@
+import { GraphQLRequestContext } from '@codelab/backend/abstract/types'
 import { fieldRepository } from '@codelab/backend/application'
 import { MutationUpsertFieldArgs } from '@codelab/shared/abstract/codegen'
 import { IFieldResolver } from '@graphql-tools/utils'
 
 export const upsertField: IFieldResolver<
-  unknown,
-  unknown,
+  undefined,
+  GraphQLRequestContext,
   MutationUpsertFieldArgs
 > = async (_, args) => {
   return fieldRepository.upsertField(args)

--- a/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
@@ -9,13 +9,5 @@ export const baseTypes: IFieldResolver<
   undefined,
   QueryBaseTypesArgs
 > = (_, args) => async (txn: Transaction) => {
-  const [items, totalCount] = await Promise.all([
-    typeRepository.baseTypes(txn, args),
-    typeRepository.countBaseTypes(txn, args?.options?.offset || 0),
-  ])
-
-  return {
-    items,
-    totalCount,
-  }
+  return typeRepository.baseTypes(txn, args)
 }

--- a/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
@@ -6,7 +6,7 @@ import { Transaction } from 'neo4j-driver'
 
 export const baseTypes: IFieldResolver<
   GraphQLRequestContext,
-  undefined,
+  unknown,
   QueryBaseTypesArgs
 > = (_, args) => async (txn: Transaction) => {
   return typeRepository.baseTypes(txn, args)

--- a/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
@@ -1,18 +1,21 @@
-// rename
 import { typeRepository } from '@codelab/backend/application'
 import { QueryBaseTypesArgs } from '@codelab/shared/abstract/codegen'
 import { IFieldResolver } from '@graphql-tools/utils'
+import { GraphQLRequestContext } from 'graphql-request/dist/types'
 import { Transaction } from 'neo4j-driver'
 
-export const baseTypes: IFieldResolver<any, any, QueryBaseTypesArgs> =
-  (_, args) => async (txn: Transaction) => {
-    const [items, totalCount] = await Promise.all([
-      typeRepository.baseTypes(txn, args),
-      typeRepository.countBaseTypes(txn, args?.options?.offset || 0),
-    ])
+export const baseTypes: IFieldResolver<
+  GraphQLRequestContext,
+  undefined,
+  QueryBaseTypesArgs
+> = (_, args) => async (txn: Transaction) => {
+  const [items, totalCount] = await Promise.all([
+    typeRepository.baseTypes(txn, args),
+    typeRepository.countBaseTypes(txn, args?.options?.offset || 0),
+  ])
 
-    return {
-      items,
-      totalCount,
-    }
+  return {
+    items,
+    totalCount,
   }
+}

--- a/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/type/query/baseTypes.resolver.ts
@@ -1,0 +1,18 @@
+// rename
+import { typeRepository } from '@codelab/backend/application'
+import { QueryBaseTypesArgs } from '@codelab/shared/abstract/codegen'
+import { IFieldResolver } from '@graphql-tools/utils'
+import { Transaction } from 'neo4j-driver'
+
+export const baseTypes: IFieldResolver<any, any, QueryBaseTypesArgs> =
+  (_, args) => async (txn: Transaction) => {
+    const [items, totalCount] = await Promise.all([
+      typeRepository.baseTypes(txn, args),
+      typeRepository.countBaseTypes(txn, args?.options?.offset || 0),
+    ])
+
+    return {
+      items,
+      totalCount,
+    }
+  }

--- a/libs/backend/graphql/src/resolvers/type/query/index.ts
+++ b/libs/backend/graphql/src/resolvers/type/query/index.ts
@@ -1,0 +1,1 @@
+export * from './baseTypes.resolver'

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/countBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/countBaseTypes.cypher
@@ -1,0 +1,3 @@
+match(type:Type)
+return count(type)
+skip $skip

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/countBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/countBaseTypes.cypher
@@ -1,3 +1,0 @@
-match(type:Type)
-return count(type)
-skip $skip

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -1,0 +1,6 @@
+match(type:Type)-[:OWNED_BY]-(owner:User)
+return type,owner
+
+order by type.id
+skip $skip
+limit $limit

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -1,5 +1,8 @@
+match(type:Type)
+with count(type) - $limit as totalCount
+
 match(type:Type)-[:OWNED_BY]-(owner:User)
-return type,owner
+return type,owner,totalCount
 
 order by type.id
 skip $skip

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/getBaseTypes.cypher
@@ -1,9 +1,9 @@
-match(type:Type)
-with count(type) - $limit as totalCount
+MATCH(type:Type)
+WITH count(type) - $limit as totalCount
 
-match(type:Type)-[:OWNED_BY]-(owner:User)
-return type,owner,totalCount
+MATCH(type:Type)-[:OWNED_BY]-(owner:User)
+RETURN type, owner, totalCount
 
-order by type.id
-skip $skip
-limit $limit
+ORDER by type.id
+SKIP $skip
+LIMIT $limit

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/index.ts
@@ -1,4 +1,6 @@
+import countBaseTypes from './countBaseTypes.cypher'
 import connectField from './field/connectField.cypher'
+import getBaseTypes from './getBaseTypes.cypher'
 import getTypeDescendants from './getTypeDescendants.cypher'
 import getTypeDescendantsOGM from './getTypeDescendantsOGM.cypher'
 import getTypeReferences from './getTypeReferences.cypher'
@@ -6,6 +8,8 @@ import isTypeDescendantOf from './isTypeDescendantOf.cypher'
 
 export {
   connectField,
+  countBaseTypes,
+  getBaseTypes,
   getTypeDescendants,
   getTypeDescendantsOGM,
   getTypeReferences,

--- a/libs/backend/infra/adapter/neo4j/src/cypher/type/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/type/index.ts
@@ -1,4 +1,3 @@
-import countBaseTypes from './countBaseTypes.cypher'
 import connectField from './field/connectField.cypher'
 import getBaseTypes from './getBaseTypes.cypher'
 import getTypeDescendants from './getTypeDescendants.cypher'
@@ -8,7 +7,6 @@ import isTypeDescendantOf from './isTypeDescendantOf.cypher'
 
 export {
   connectField,
-  countBaseTypes,
   getBaseTypes,
   getTypeDescendants,
   getTypeDescendantsOGM,

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/user.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/user.schema.ts
@@ -15,7 +15,7 @@ export const userSchema = gql`
     auth0Id: String! @unique
     email: String!
     username: String! @unique
-    types: [TypeBase!]!
+    types: [BaseType!]!
       @relationship(type: "OWNED_BY", direction: IN, properties: "OwnedBy")
     apps: [App!]! @relationship(type: "OWNED_BY", direction: IN)
     elements: [Element!]! @relationship(type: "OWNED_BY", direction: IN)

--- a/libs/backend/infra/adapter/neo4j/src/schema/type/type.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/type/type.schema.ts
@@ -38,6 +38,16 @@ export const typeSchema = gql`
     label: String!
   }
 
+  input GetBaseTypesOptions {
+    limit: Int
+    offset: Int
+  }
+
+  type GetBaseTypesReturn {
+    items: [BaseType!]!
+    totalCount: Int!
+  }
+
   type Query {
     """
     Does a recursive check to see if the parent type (parentTypeId) contains the descendant type (descendantTypeId) at any level of nesting. Useful for checking for recursion
@@ -51,9 +61,13 @@ export const typeSchema = gql`
     """
     getTypeReferences(typeId: ID!): [TypeReference!]
       @cypher(statement: """${getTypeReferences}""")
+
+   baseTypes(
+    options: GetBaseTypesOptions
+   ):GetBaseTypesReturn!
   }
 
-  interface TypeBase
+    interface IBaseType
   {
     id: ID! @id(autogenerate: false)
     kind: TypeKind! @readonly
@@ -66,18 +80,18 @@ export const typeSchema = gql`
         properties: "OwnedBy",
         direction: OUT
       )
-
-    # Any type could be used a field for some interface
-#    fieldFor: [TypeBase!]!
-#      @relationship(
-#        type: "INTERFACE_FIELD"
-#        direction: IN
-#        properties: "Field"
-#      )
   }
 
+ # for defining returning data only
+ type BaseType implements IBaseType @exclude(operations: [CREATE, READ, UPDATE, DELETE]) {
+   id: ID!
+   kind: TypeKind! 
+   name: String! @unique
+   owner: User!
+ } 
+
   # https://github.com/neo4j/graphql/issues/1105
- extend interface TypeBase
+ extend interface IBaseType
  @auth(
    rules: [
      {
@@ -104,12 +118,12 @@ export const typeSchema = gql`
   """
   Base atomic building block of the type system. Represents primitive types - String, Integer, Float, Boolean
   """
-  type PrimitiveType implements TypeBase {
+  type PrimitiveType implements IBaseType @node(additionalLabels: ["Type"])  {
     id: ID!
     kind: TypeKind! @default(value: PrimitiveType)
     name: String! @unique
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
     # There seems to be an issue with the unique constrain right now https://github.com/neo4j/graphql/issues/915
     primitiveKind: PrimitiveTypeKind! @unique
   }
@@ -125,7 +139,7 @@ export const typeSchema = gql`
   ArrayType Allows defining a variable number of items of a given type.
   Contains a reference to another type which is the array item type.
   """
-  type ArrayType implements TypeBase & WithDescendants {
+  type ArrayType implements IBaseType & WithDescendants @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: ArrayType)
     name: String!
@@ -141,7 +155,7 @@ export const typeSchema = gql`
   """
   Allows picking one of a set of types
   """
-  type UnionType implements TypeBase & WithDescendants {
+  type UnionType implements IBaseType & WithDescendants @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: UnionType)
     name: String! @unique
@@ -165,12 +179,12 @@ export const typeSchema = gql`
   """
   Represents an object type with multiple fields
   """
-  type InterfaceType implements TypeBase & WithDescendants {
+  type InterfaceType implements IBaseType & WithDescendants @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: InterfaceType)
     name: String!
     owner: User!
-    fieldFor: [TypeBase!]!
+    fieldFor: [BaseType!]!
     descendantTypesIds: [ID!]!
 
     # List of atoms that have this interface as their api type
@@ -181,7 +195,7 @@ export const typeSchema = gql`
       )
     # Fields are defined as a set of list to other types
     # The field data is stored as relationship properties
-    fields: [TypeBase!]!
+    fields: [BaseType!]!
       @relationship(
         type: "INTERFACE_FIELD"
         direction: OUT
@@ -199,12 +213,12 @@ export const typeSchema = gql`
   - ReactNodeType: Component select box, results it 'ReactNode' value
   - ElementType: Current tree element select box, results it 'ReactNode' value
   """
-  type ElementType implements TypeBase {
+  type ElementType implements IBaseType @node(additionalLabels: ["Type"])  {
     id: ID!
     kind: TypeKind! @default(value: ElementType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
     """
     Allows scoping the type of element to only descendants, children or all elements
     """
@@ -222,12 +236,12 @@ export const typeSchema = gql`
   - ReactNodeType: Component select box, results it 'ReactNode' value
   - ElementType: Current tree element select box, results it 'ReactNode' value
   """
-  type RenderPropsType implements TypeBase {
+  type RenderPropsType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: RenderPropsType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   """
@@ -240,12 +254,12 @@ export const typeSchema = gql`
   - ReactNodeType: Component select box, results it 'ReactNode' value
   - ElementType: Current tree element select box, results it 'ReactNode' value
   """
-  type ReactNodeType implements TypeBase {
+  type ReactNodeType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: ReactNodeType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   ${elementTypeTypeKindSchema}
@@ -255,12 +269,12 @@ export const typeSchema = gql`
   The value gets passed to the render pipe as a Enum Type Value id.
   The actual value must be de-referenced by the id.
   """
-  type EnumType implements TypeBase {
+  type EnumType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: EnumType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
     allowedValues: [EnumTypeValue!]!
       @relationship(
         type: "ALLOWED_VALUE",
@@ -278,56 +292,56 @@ export const typeSchema = gql`
   """
   Allows picking a lambda
   """
-  type LambdaType implements TypeBase {
+  type LambdaType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: LambdaType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   """
   Allows picking a page from the list of pages
   """
-  type PageType implements TypeBase {
+  type PageType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: PageType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   """
   Allows picking a app from the list of apps
   """
-  type AppType implements TypeBase {
+  type AppType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: AppType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   """
   Allows picking a action from the list of actions
   """
-  type ActionType implements TypeBase {
+  type ActionType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: ActionType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
   }
 
   """
   Allows editing the value using a code mirror editor
   """
-  type CodeMirrorType implements TypeBase {
+  type CodeMirrorType implements IBaseType @node(additionalLabels: ["Type"]) {
     id: ID!
     kind: TypeKind! @default(value: CodeMirrorType)
     name: String!
     owner: User!
-#    fieldFor: [TypeBase!]!
+#    fieldFor: [BaseType!]!
     language: CodeMirrorLanguage!
   }
 

--- a/libs/backend/infra/adapter/neo4j/src/schema/type/type.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/type/type.schema.ts
@@ -62,9 +62,9 @@ export const typeSchema = gql`
     getTypeReferences(typeId: ID!): [TypeReference!]
       @cypher(statement: """${getTypeReferences}""")
 
-   baseTypes(
-    options: GetBaseTypesOptions
-   ):GetBaseTypesReturn!
+    baseTypes(
+      options: GetBaseTypesOptions
+    ): GetBaseTypesReturn!
   }
 
     interface IBaseType
@@ -85,10 +85,10 @@ export const typeSchema = gql`
  # for defining returning data only
  type BaseType implements IBaseType @exclude(operations: [CREATE, READ, UPDATE, DELETE]) {
    id: ID!
-   kind: TypeKind! 
+   kind: TypeKind!
    name: String! @unique
    owner: User!
- } 
+ }
 
   # https://github.com/neo4j/graphql/issues/1105
  extend interface IBaseType

--- a/libs/frontend/abstract/core/src/domain/type/fragments/action-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/action-type.fragment.graphql
@@ -1,3 +1,3 @@
 fragment ActionType on ActionType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/action-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/action-type.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type ActionTypeFragment = TypeBase_ActionType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type ActionTypeFragment = BaseType_ActionType_Fragment
 
 export const ActionTypeFragmentDoc = gql`
   fragment ActionType on ActionType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/app-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/app-type.fragment.graphql
@@ -1,3 +1,3 @@
 fragment AppType on AppType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/app-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/app-type.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type AppTypeFragment = TypeBase_AppType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type AppTypeFragment = BaseType_AppType_Fragment
 
 export const AppTypeFragmentDoc = gql`
   fragment AppType on AppType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/array-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/array-type.fragment.graphql
@@ -1,7 +1,7 @@
 fragment ArrayType on ArrayType {
-  ...TypeBase
+  ...BaseType
   itemType {
-    ... on TypeBase {
+    ... on IBaseType {
       id
       name
     }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/array-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/array-type.fragment.graphql.gen.ts
@@ -1,24 +1,25 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 export type ArrayTypeFragment = {
   itemType:
     | { id: string; name: string }
@@ -34,19 +35,19 @@ export type ArrayTypeFragment = {
     | { id: string; name: string }
     | { id: string; name: string }
     | { id: string; name: string }
-} & TypeBase_ArrayType_Fragment
+} & BaseType_ArrayType_Fragment
 
 export const ArrayTypeFragmentDoc = gql`
   fragment ArrayType on ArrayType {
-    ...TypeBase
+    ...BaseType
     itemType {
-      ... on TypeBase {
+      ... on IBaseType {
         id
         name
       }
     }
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/base-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/base-type.fragment.graphql
@@ -1,4 +1,4 @@
-fragment TypeBase on TypeBase {
+fragment BaseType on IBaseType {
   # Need this to narrow down type on frontend
   __typename
   kind

--- a/libs/frontend/abstract/core/src/domain/type/fragments/base-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/base-type.fragment.graphql.gen.ts
@@ -1,0 +1,165 @@
+import * as Types from '@codelab/shared/abstract/codegen'
+
+import { GraphQLClient } from 'graphql-request'
+import * as Dom from 'graphql-request/dist/types.dom'
+import { gql } from 'graphql-tag'
+export type BaseType_ActionType_Fragment = {
+  __typename: 'ActionType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_AppType_Fragment = {
+  __typename: 'AppType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_ArrayType_Fragment = {
+  __typename: 'ArrayType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_BaseType_Fragment = {
+  __typename: 'BaseType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_CodeMirrorType_Fragment = {
+  __typename: 'CodeMirrorType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_ElementType_Fragment = {
+  __typename: 'ElementType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_EnumType_Fragment = {
+  __typename: 'EnumType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_InterfaceType_Fragment = {
+  __typename: 'InterfaceType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_LambdaType_Fragment = {
+  __typename: 'LambdaType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_PageType_Fragment = {
+  __typename: 'PageType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_PrimitiveType_Fragment = {
+  __typename: 'PrimitiveType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_ReactNodeType_Fragment = {
+  __typename: 'ReactNodeType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_RenderPropsType_Fragment = {
+  __typename: 'RenderPropsType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseType_UnionType_Fragment = {
+  __typename: 'UnionType'
+  kind: Types.TypeKind
+  id: string
+  name: string
+  owner: { id: string; auth0Id: string }
+}
+
+export type BaseTypeFragment =
+  | BaseType_ActionType_Fragment
+  | BaseType_AppType_Fragment
+  | BaseType_ArrayType_Fragment
+  | BaseType_BaseType_Fragment
+  | BaseType_CodeMirrorType_Fragment
+  | BaseType_ElementType_Fragment
+  | BaseType_EnumType_Fragment
+  | BaseType_InterfaceType_Fragment
+  | BaseType_LambdaType_Fragment
+  | BaseType_PageType_Fragment
+  | BaseType_PrimitiveType_Fragment
+  | BaseType_ReactNodeType_Fragment
+  | BaseType_RenderPropsType_Fragment
+  | BaseType_UnionType_Fragment
+
+export const BaseTypeFragmentDoc = gql`
+  fragment BaseType on IBaseType {
+    __typename
+    kind
+    id
+    owner {
+      id
+      auth0Id
+    }
+    name
+  }
+`
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+) => Promise<T>
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+) => action()
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
+  return {}
+}
+export type Sdk = ReturnType<typeof getSdk>

--- a/libs/frontend/abstract/core/src/domain/type/fragments/code-mirror-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/code-mirror-type.fragment.graphql
@@ -1,4 +1,4 @@
 fragment CodeMirrorType on CodeMirrorType {
-  ...TypeBase
+  ...BaseType
   language
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/code-mirror-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/code-mirror-type.fragment.graphql.gen.ts
@@ -1,34 +1,35 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 export type CodeMirrorTypeFragment = {
   language: Types.CodeMirrorLanguage
-} & TypeBase_CodeMirrorType_Fragment
+} & BaseType_CodeMirrorType_Fragment
 
 export const CodeMirrorTypeFragmentDoc = gql`
   fragment CodeMirrorType on CodeMirrorType {
-    ...TypeBase
+    ...BaseType
     language
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/element-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/element-type.fragment.graphql
@@ -1,4 +1,4 @@
 fragment ElementType on ElementType {
-  ...TypeBase
+  ...BaseType
   elementKind
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/element-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/element-type.fragment.graphql.gen.ts
@@ -1,34 +1,35 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 export type ElementTypeFragment = {
   elementKind: Types.ElementTypeKind
-} & TypeBase_ElementType_Fragment
+} & BaseType_ElementType_Fragment
 
 export const ElementTypeFragmentDoc = gql`
   fragment ElementType on ElementType {
-    ...TypeBase
+    ...BaseType
     elementKind
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/enum-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/enum-type.fragment.graphql
@@ -1,5 +1,5 @@
 fragment EnumType on EnumType {
-  ...TypeBase
+  ...BaseType
   allowedValues {
     ...EnumTypeValue
   }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/enum-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/enum-type.fragment.graphql.gen.ts
@@ -1,38 +1,39 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { EnumTypeValueFragment } from './enum-type-value.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 import { EnumTypeValueFragmentDoc } from './enum-type-value.fragment.graphql.gen'
 export type EnumTypeFragment = {
   allowedValues: Array<EnumTypeValueFragment>
-} & TypeBase_EnumType_Fragment
+} & BaseType_EnumType_Fragment
 
 export const EnumTypeFragmentDoc = gql`
   fragment EnumType on EnumType {
-    ...TypeBase
+    ...BaseType
     allowedValues {
       ...EnumTypeValue
     }
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
   ${EnumTypeValueFragmentDoc}
 `
 

--- a/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql
@@ -5,7 +5,7 @@ fragment Field on InterfaceTypeFieldsRelationship {
   description
   validationRules
   fieldType: node {
-    ... on TypeBase {
+    ... on IBaseType {
       id
     }
   }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/field.fragment.graphql.gen.ts
@@ -9,20 +9,7 @@ export type FieldFragment = {
   name?: string | null
   description?: string | null
   validationRules?: string | null
-  fieldType:
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
-    | { id: string }
+  fieldType: { id: string }
 }
 
 export const FieldFragmentDoc = gql`
@@ -33,7 +20,7 @@ export const FieldFragmentDoc = gql`
     description
     validationRules
     fieldType: node {
-      ... on TypeBase {
+      ... on IBaseType {
         id
       }
     }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/interface.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/interface.fragment.graphql
@@ -1,5 +1,5 @@
 fragment InterfaceType on InterfaceType {
-  ...TypeBase
+  ...BaseType
   ownerConnection {
     edges {
       data

--- a/libs/frontend/abstract/core/src/domain/type/fragments/interface.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/interface.fragment.graphql.gen.ts
@@ -1,34 +1,35 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { FieldFragment } from './field.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 import { FieldFragmentDoc } from './field.fragment.graphql.gen'
 export type InterfaceTypeFragment = {
   ownerConnection: { edges: Array<{ data: string }> }
   fieldsConnection: { edges: Array<FieldFragment> }
-} & TypeBase_InterfaceType_Fragment
+} & BaseType_InterfaceType_Fragment
 
 export const InterfaceTypeFragmentDoc = gql`
   fragment InterfaceType on InterfaceType {
-    ...TypeBase
+    ...BaseType
     ownerConnection {
       edges {
         data
@@ -40,7 +41,7 @@ export const InterfaceTypeFragmentDoc = gql`
       }
     }
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
   ${FieldFragmentDoc}
 `
 

--- a/libs/frontend/abstract/core/src/domain/type/fragments/lambda-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/lambda-type.fragment.graphql
@@ -1,3 +1,3 @@
 fragment LambdaType on LambdaType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/lambda-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/lambda-type.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type LambdaTypeFragment = TypeBase_LambdaType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type LambdaTypeFragment = BaseType_LambdaType_Fragment
 
 export const LambdaTypeFragmentDoc = gql`
   fragment LambdaType on LambdaType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/page-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/page-type.fragment.graphql
@@ -1,3 +1,3 @@
 fragment PageType on PageType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/page-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/page-type.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type PageTypeFragment = TypeBase_PageType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type PageTypeFragment = BaseType_PageType_Fragment
 
 export const PageTypeFragmentDoc = gql`
   fragment PageType on PageType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/primitive-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/primitive-type.fragment.graphql
@@ -1,4 +1,4 @@
 fragment PrimitiveType on PrimitiveType {
-  ...TypeBase
+  ...BaseType
   primitiveKind
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/primitive-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/primitive-type.fragment.graphql.gen.ts
@@ -1,34 +1,35 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 export type PrimitiveTypeFragment = {
   primitiveKind: Types.PrimitiveTypeKind
-} & TypeBase_PrimitiveType_Fragment
+} & BaseType_PrimitiveType_Fragment
 
 export const PrimitiveTypeFragmentDoc = gql`
   fragment PrimitiveType on PrimitiveType {
-    ...TypeBase
+    ...BaseType
     primitiveKind
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/react-node-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/react-node-type.fragment.graphql
@@ -1,3 +1,3 @@
 fragment ReactNodeType on ReactNodeType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/react-node-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/react-node-type.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type ReactNodeTypeFragment = TypeBase_ReactNodeType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type ReactNodeTypeFragment = BaseType_ReactNodeType_Fragment
 
 export const ReactNodeTypeFragmentDoc = gql`
   fragment ReactNodeType on ReactNodeType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/render-props.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/render-props.fragment.graphql
@@ -1,3 +1,3 @@
 fragment RenderPropsType on RenderPropsType {
-  ...TypeBase
+  ...BaseType
 }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/render-props.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/render-props.fragment.graphql.gen.ts
@@ -1,31 +1,32 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
-export type RenderPropsTypeFragment = TypeBase_RenderPropsType_Fragment
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
+export type RenderPropsTypeFragment = BaseType_RenderPropsType_Fragment
 
 export const RenderPropsTypeFragmentDoc = gql`
   fragment RenderPropsType on RenderPropsType {
-    ...TypeBase
+    ...BaseType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/fragments/type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/type.fragment.graphql
@@ -1,5 +1,5 @@
-fragment Type on TypeBase {
-  ...TypeBase
+fragment Type on IBaseType {
+  ...BaseType
   ...ArrayType
   ...UnionType
   ...EnumType

--- a/libs/frontend/abstract/core/src/domain/type/fragments/type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/type.fragment.graphql.gen.ts
@@ -1,20 +1,21 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { ArrayTypeFragment } from './array-type.fragment.graphql.gen'
 import { UnionTypeFragment } from './union-type.fragment.graphql.gen'
 import { EnumTypeFragment } from './enum-type.fragment.graphql.gen'
@@ -30,7 +31,7 @@ import { ActionTypeFragment } from './action-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 import { ArrayTypeFragmentDoc } from './array-type.fragment.graphql.gen'
 import { UnionTypeFragmentDoc } from './union-type.fragment.graphql.gen'
 import { EnumTypeFragmentDoc } from './enum-type.fragment.graphql.gen'
@@ -43,47 +44,50 @@ import { CodeMirrorTypeFragmentDoc } from './code-mirror-type.fragment.graphql.g
 import { PageTypeFragmentDoc } from './page-type.fragment.graphql.gen'
 import { AppTypeFragmentDoc } from './app-type.fragment.graphql.gen'
 import { ActionTypeFragmentDoc } from './action-type.fragment.graphql.gen'
-export type Type_ActionType_Fragment = TypeBase_ActionType_Fragment &
+export type Type_ActionType_Fragment = BaseType_ActionType_Fragment &
   ActionTypeFragment
 
-export type Type_AppType_Fragment = TypeBase_AppType_Fragment & AppTypeFragment
+export type Type_AppType_Fragment = BaseType_AppType_Fragment & AppTypeFragment
 
-export type Type_ArrayType_Fragment = TypeBase_ArrayType_Fragment &
+export type Type_ArrayType_Fragment = BaseType_ArrayType_Fragment &
   ArrayTypeFragment
 
-export type Type_CodeMirrorType_Fragment = TypeBase_CodeMirrorType_Fragment &
+export type Type_BaseType_Fragment = BaseType_BaseType_Fragment
+
+export type Type_CodeMirrorType_Fragment = BaseType_CodeMirrorType_Fragment &
   CodeMirrorTypeFragment
 
-export type Type_ElementType_Fragment = TypeBase_ElementType_Fragment &
+export type Type_ElementType_Fragment = BaseType_ElementType_Fragment &
   ElementTypeFragment
 
-export type Type_EnumType_Fragment = TypeBase_EnumType_Fragment &
+export type Type_EnumType_Fragment = BaseType_EnumType_Fragment &
   EnumTypeFragment
 
-export type Type_InterfaceType_Fragment = TypeBase_InterfaceType_Fragment &
+export type Type_InterfaceType_Fragment = BaseType_InterfaceType_Fragment &
   InterfaceTypeFragment
 
-export type Type_LambdaType_Fragment = TypeBase_LambdaType_Fragment &
+export type Type_LambdaType_Fragment = BaseType_LambdaType_Fragment &
   LambdaTypeFragment
 
-export type Type_PageType_Fragment = TypeBase_PageType_Fragment &
+export type Type_PageType_Fragment = BaseType_PageType_Fragment &
   PageTypeFragment
 
-export type Type_PrimitiveType_Fragment = TypeBase_PrimitiveType_Fragment &
+export type Type_PrimitiveType_Fragment = BaseType_PrimitiveType_Fragment &
   PrimitiveTypeFragment
 
-export type Type_ReactNodeType_Fragment = TypeBase_ReactNodeType_Fragment
+export type Type_ReactNodeType_Fragment = BaseType_ReactNodeType_Fragment
 
-export type Type_RenderPropsType_Fragment = TypeBase_RenderPropsType_Fragment &
+export type Type_RenderPropsType_Fragment = BaseType_RenderPropsType_Fragment &
   RenderPropsTypeFragment
 
-export type Type_UnionType_Fragment = TypeBase_UnionType_Fragment &
+export type Type_UnionType_Fragment = BaseType_UnionType_Fragment &
   UnionTypeFragment
 
 export type TypeFragment =
   | Type_ActionType_Fragment
   | Type_AppType_Fragment
   | Type_ArrayType_Fragment
+  | Type_BaseType_Fragment
   | Type_CodeMirrorType_Fragment
   | Type_ElementType_Fragment
   | Type_EnumType_Fragment
@@ -96,8 +100,8 @@ export type TypeFragment =
   | Type_UnionType_Fragment
 
 export const TypeFragmentDoc = gql`
-  fragment Type on TypeBase {
-    ...TypeBase
+  fragment Type on IBaseType {
+    ...BaseType
     ...ArrayType
     ...UnionType
     ...EnumType
@@ -111,7 +115,7 @@ export const TypeFragmentDoc = gql`
     ...AppType
     ...ActionType
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
   ${ArrayTypeFragmentDoc}
   ${UnionTypeFragmentDoc}
   ${EnumTypeFragmentDoc}

--- a/libs/frontend/abstract/core/src/domain/type/fragments/union-type.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/union-type.fragment.graphql
@@ -1,7 +1,7 @@
 fragment UnionType on UnionType {
-  ...TypeBase
+  ...BaseType
   typesOfUnionType {
-    ... on TypeBase {
+    ... on IBaseType {
       id
       name
     }

--- a/libs/frontend/abstract/core/src/domain/type/fragments/union-type.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/type/fragments/union-type.fragment.graphql.gen.ts
@@ -1,24 +1,25 @@
 import * as Types from '@codelab/shared/abstract/codegen'
 
 import {
-  TypeBase_ActionType_Fragment,
-  TypeBase_AppType_Fragment,
-  TypeBase_ArrayType_Fragment,
-  TypeBase_CodeMirrorType_Fragment,
-  TypeBase_ElementType_Fragment,
-  TypeBase_EnumType_Fragment,
-  TypeBase_InterfaceType_Fragment,
-  TypeBase_LambdaType_Fragment,
-  TypeBase_PageType_Fragment,
-  TypeBase_PrimitiveType_Fragment,
-  TypeBase_ReactNodeType_Fragment,
-  TypeBase_RenderPropsType_Fragment,
-  TypeBase_UnionType_Fragment,
-} from './type-base.fragment.graphql.gen'
+  BaseType_ActionType_Fragment,
+  BaseType_AppType_Fragment,
+  BaseType_ArrayType_Fragment,
+  BaseType_BaseType_Fragment,
+  BaseType_CodeMirrorType_Fragment,
+  BaseType_ElementType_Fragment,
+  BaseType_EnumType_Fragment,
+  BaseType_InterfaceType_Fragment,
+  BaseType_LambdaType_Fragment,
+  BaseType_PageType_Fragment,
+  BaseType_PrimitiveType_Fragment,
+  BaseType_ReactNodeType_Fragment,
+  BaseType_RenderPropsType_Fragment,
+  BaseType_UnionType_Fragment,
+} from './base-type.fragment.graphql.gen'
 import { GraphQLClient } from 'graphql-request'
 import * as Dom from 'graphql-request/dist/types.dom'
 import { gql } from 'graphql-tag'
-import { TypeBaseFragmentDoc } from './type-base.fragment.graphql.gen'
+import { BaseTypeFragmentDoc } from './base-type.fragment.graphql.gen'
 export type UnionTypeFragment = {
   typesOfUnionType: Array<
     | { id: string; name: string }
@@ -35,19 +36,19 @@ export type UnionTypeFragment = {
     | { id: string; name: string }
     | { id: string; name: string }
   >
-} & TypeBase_UnionType_Fragment
+} & BaseType_UnionType_Fragment
 
 export const UnionTypeFragmentDoc = gql`
   fragment UnionType on UnionType {
-    ...TypeBase
+    ...BaseType
     typesOfUnionType {
-      ... on TypeBase {
+      ... on IBaseType {
         id
         name
       }
     }
   }
-  ${TypeBaseFragmentDoc}
+  ${BaseTypeFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(

--- a/libs/frontend/abstract/core/src/domain/type/type.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/type/type.service.interface.ts
@@ -1,4 +1,9 @@
-import { GetTypesQuery, TypeBaseWhere } from '@codelab/shared/abstract/codegen'
+import { OGM_TYPES } from '@codelab/backend/abstract/codegen'
+import {
+  BaseTypeWhere,
+  GetTypesQuery,
+  PrimitiveTypeKind,
+} from '@codelab/shared/abstract/codegen'
 import { IPrimitiveTypeKind } from '@codelab/shared/abstract/core'
 import { Maybe, Nullable } from '@codelab/shared/abstract/types'
 import { ArraySet, ObjectMap, Ref } from 'mobx-keystone'
@@ -25,7 +30,7 @@ export interface IFieldModalProperties {
 
 export interface ITypeService
   extends ICRUDService<IAnyType, ICreateTypeDTO, IUpdateTypeDTO>,
-    IQueryService<IAnyType, TypeBaseWhere>,
+    IQueryService<IAnyType, BaseTypeWhere>,
     ICRUDModalService<Ref<IAnyType>, { type: Maybe<IAnyType> }> {
   getInterfaceAndDescendants(id: IInterfaceTypeRef): Promise<IInterfaceType>
   types: ObjectMap<IAnyType>

--- a/libs/frontend/domain/page/src/graphql/page.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/page/src/graphql/page.endpoints.graphql.gen.ts
@@ -8,6 +8,7 @@ import {
   Type_ActionType_Fragment,
   Type_AppType_Fragment,
   Type_ArrayType_Fragment,
+  Type_BaseType_Fragment,
   Type_CodeMirrorType_Fragment,
   Type_ElementType_Fragment,
   Type_EnumType_Fragment,

--- a/libs/frontend/domain/type/src/graphql/create-type.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/create-type.endpoints.graphql.gen.ts
@@ -4,6 +4,7 @@ import {
   Type_ActionType_Fragment,
   Type_AppType_Fragment,
   Type_ArrayType_Fragment,
+  Type_BaseType_Fragment,
   Type_CodeMirrorType_Fragment,
   Type_ElementType_Fragment,
   Type_EnumType_Fragment,

--- a/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/get-type.endpoints.graphql.gen.ts
@@ -4,6 +4,7 @@ import {
   Type_ActionType_Fragment,
   Type_AppType_Fragment,
   Type_ArrayType_Fragment,
+  Type_BaseType_Fragment,
   Type_CodeMirrorType_Fragment,
   Type_ElementType_Fragment,
   Type_EnumType_Fragment,

--- a/libs/frontend/domain/type/src/graphql/update-type.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/type/src/graphql/update-type.endpoints.graphql.gen.ts
@@ -4,6 +4,7 @@ import {
   Type_ActionType_Fragment,
   Type_AppType_Fragment,
   Type_ArrayType_Fragment,
+  Type_BaseType_Fragment,
   Type_CodeMirrorType_Fragment,
   Type_ElementType_Fragment,
   Type_EnumType_Fragment,

--- a/libs/frontend/domain/type/src/store/models/action-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/action-type.model.ts
@@ -4,7 +4,7 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, owner }: IAnyActionTypeDTO) => {
   assertIsTypeKind(kind, ITypeKind.ActionType)
@@ -14,7 +14,7 @@ const hydrate = ({ id, kind, name, owner }: IAnyActionTypeDTO) => {
 
 @model('@codelab/ActionType')
 export class ActionType
-  extends ExtendedModel(createTypeBase(ITypeKind.ActionType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.ActionType), {})
   implements IAnyActionType
 {
   public static hydrate = hydrate

--- a/libs/frontend/domain/type/src/store/models/app-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/app-type.model.ts
@@ -1,7 +1,7 @@
 import type { IAppType, IAppTypeDTO } from '@codelab/frontend/abstract/core'
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, owner }: IAppTypeDTO): AppType => {
   assertIsTypeKind(kind, ITypeKind.AppType)
@@ -16,7 +16,7 @@ const hydrate = ({ id, kind, name, owner }: IAppTypeDTO): AppType => {
 
 @model('@codelab/AppType')
 export class AppType
-  extends ExtendedModel(createTypeBase(ITypeKind.AppType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.AppType), {})
   implements IAppType
 {
   // @modelAction

--- a/libs/frontend/domain/type/src/store/models/array-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/array-type.model.ts
@@ -7,7 +7,7 @@ import type {
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction, prop, Ref } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 import { typeRef } from './union-type.model'
 
 const hydrate = (fragment: IArrayTypeDTO): ArrayType => {
@@ -31,7 +31,7 @@ const hydrate = (fragment: IArrayTypeDTO): ArrayType => {
 
 @model('@codelab/ArrayType')
 export class ArrayType
-  extends ExtendedModel(createTypeBase(ITypeKind.ArrayType), {
+  extends ExtendedModel(createBaseType(ITypeKind.ArrayType), {
     itemType: prop<Ref<IAnyType>>(),
   })
   implements IArrayType

--- a/libs/frontend/domain/type/src/store/models/base-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/base-type.model.ts
@@ -3,7 +3,7 @@ import { ITypeKind } from '@codelab/shared/abstract/core'
 import { idProp, Model, prop } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
 
-export const createTypeBase = <T extends ITypeKind>(typeKind: T) => {
+export const createBaseType = <T extends ITypeKind>(typeKind: T) => {
   return class
     extends Model({
       id: idProp,

--- a/libs/frontend/domain/type/src/store/models/code-mirror-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/code-mirror-type.model.ts
@@ -7,7 +7,7 @@ import { CodeMirrorLanguage } from '@codelab/shared/abstract/codegen'
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({
   id,
@@ -29,7 +29,7 @@ const hydrate = ({
 
 @model('@codelab/CodeMirrorType')
 export class CodeMirrorType
-  extends ExtendedModel(createTypeBase(ITypeKind.CodeMirrorType), {
+  extends ExtendedModel(createBaseType(ITypeKind.CodeMirrorType), {
     language: prop<CodeMirrorLanguage>(),
   })
   implements ICodeMirrorType

--- a/libs/frontend/domain/type/src/store/models/element-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/element-type.model.ts
@@ -10,7 +10,7 @@ import {
 } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, elementKind, owner }: IElementTypeDTO) => {
   assertIsTypeKind(kind, ITypeKind.ElementType)
@@ -26,7 +26,7 @@ const hydrate = ({ id, kind, name, elementKind, owner }: IElementTypeDTO) => {
 
 @model('@codelab/ElementType')
 export class ElementType
-  extends ExtendedModel(createTypeBase(ITypeKind.ElementType), {
+  extends ExtendedModel(createBaseType(ITypeKind.ElementType), {
     elementKind: prop<IElementTypeKind>(),
   })
   implements IElementType

--- a/libs/frontend/domain/type/src/store/models/enum-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/enum-type.model.ts
@@ -14,7 +14,7 @@ import {
   prop,
 } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrateEnumValue = (fragment: IEnumTypeValueDTO) =>
   new EnumTypeValue({
@@ -49,7 +49,7 @@ const hydrate = ({ id, allowedValues, kind, name, owner }: IEnumTypeDTO) => {
 
 @model('@codelab/EnumType')
 export class EnumType
-  extends ExtendedModel(createTypeBase(ITypeKind.EnumType), {
+  extends ExtendedModel(createBaseType(ITypeKind.EnumType), {
     allowedValues: prop<Array<EnumTypeValue>>(() => []),
   })
   implements IEnumType

--- a/libs/frontend/domain/type/src/store/models/interface-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/interface-type.model.ts
@@ -15,7 +15,7 @@ import {
   prop,
 } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 import { Field } from './field.model'
 
 const hydrate = ({
@@ -46,7 +46,7 @@ const hydrate = ({
 
 @model('@codelab/InterfaceType')
 export class InterfaceType
-  extends ExtendedModel(createTypeBase(ITypeKind.InterfaceType), {
+  extends ExtendedModel(createBaseType(ITypeKind.InterfaceType), {
     fields: prop(() => objectMap<Field>()),
     ownerAuthId: prop<string>(),
     defaults: prop<IPropData>(),

--- a/libs/frontend/domain/type/src/store/models/lambda-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/lambda-type.model.ts
@@ -6,7 +6,7 @@ import type {
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, owner }: ILambdaTypeDTO): LambdaType => {
   assertIsTypeKind(kind, ITypeKind.LambdaType)
@@ -21,7 +21,7 @@ const hydrate = ({ id, kind, name, owner }: ILambdaTypeDTO): LambdaType => {
 
 @model('@codelab/LambdaType')
 export class LambdaType
-  extends ExtendedModel(createTypeBase(ITypeKind.LambdaType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.LambdaType), {})
   implements ILambdaType
 {
   @modelAction

--- a/libs/frontend/domain/type/src/store/models/page-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/page-type.model.ts
@@ -6,7 +6,7 @@ import type {
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, owner }: IPageTypeDTO) => {
   assertIsTypeKind(kind, ITypeKind.PageType)
@@ -16,7 +16,7 @@ const hydrate = ({ id, kind, name, owner }: IPageTypeDTO) => {
 
 @model('@codelab/PageType')
 export class PageType
-  extends ExtendedModel(createTypeBase(ITypeKind.PageType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.PageType), {})
   implements IPageType
 {
   @modelAction

--- a/libs/frontend/domain/type/src/store/models/primitive-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/primitive-type.model.ts
@@ -7,7 +7,7 @@ import { PrimitiveTypeKind } from '@codelab/shared/abstract/codegen'
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction, prop } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({
   id,
@@ -29,7 +29,7 @@ const hydrate = ({
 
 @model('@codelab/PrimitiveType')
 export class PrimitiveType
-  extends ExtendedModel(createTypeBase(ITypeKind.PrimitiveType), {
+  extends ExtendedModel(createBaseType(ITypeKind.PrimitiveType), {
     primitiveKind: prop<PrimitiveTypeKind>(),
   })
   implements IPrimitiveType

--- a/libs/frontend/domain/type/src/store/models/react-node-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/react-node-type.model.ts
@@ -6,7 +6,7 @@ import type {
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({
   id,
@@ -26,7 +26,7 @@ const hydrate = ({
 
 @model('@codelab/ReactNodeType')
 export class ReactNodeType
-  extends ExtendedModel(createTypeBase(ITypeKind.ReactNodeType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.ReactNodeType), {})
   implements IReactNodeType
 {
   @modelAction

--- a/libs/frontend/domain/type/src/store/models/render-props-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/render-props-type.model.ts
@@ -6,7 +6,7 @@ import type {
 import { assertIsTypeKind, ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model, modelAction } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({ id, kind, name, owner }: IRenderPropsTypeDTO) => {
   assertIsTypeKind(kind, ITypeKind.RenderPropsType)
@@ -21,7 +21,7 @@ const hydrate = ({ id, kind, name, owner }: IRenderPropsTypeDTO) => {
 
 @model('@codelab/RenderPropsType')
 export class RenderPropsType
-  extends ExtendedModel(createTypeBase(ITypeKind.RenderPropsType), {})
+  extends ExtendedModel(createBaseType(ITypeKind.RenderPropsType), {})
   implements IRenderPropsType
 {
   @modelAction

--- a/libs/frontend/domain/type/src/store/models/union-type.model.ts
+++ b/libs/frontend/domain/type/src/store/models/union-type.model.ts
@@ -15,7 +15,7 @@ import {
   rootRef,
 } from 'mobx-keystone'
 import { updateBaseTypeCache } from '../base-type'
-import { createTypeBase } from './base-type.model'
+import { createBaseType } from './base-type.model'
 
 const hydrate = ({
   id,
@@ -37,7 +37,7 @@ const hydrate = ({
 
 @model('@codelab/UnionType')
 export class UnionType
-  extends ExtendedModel(createTypeBase(ITypeKind.UnionType), {
+  extends ExtendedModel(createBaseType(ITypeKind.UnionType), {
     typesOfUnionType: prop<Array<Ref<IAnyType>>>(() => []),
   })
   implements IUnionType

--- a/libs/frontend/domain/type/src/store/type.service.ts
+++ b/libs/frontend/domain/type/src/store/type.service.ts
@@ -1,3 +1,4 @@
+import { OGM_TYPES } from '@codelab/backend/abstract/codegen'
 import type {
   IAnyType,
   ICreateFieldDTO,
@@ -12,7 +13,7 @@ import type {
 } from '@codelab/frontend/abstract/core'
 import { getElementService } from '@codelab/frontend/presenter/container'
 import { ModalService, throwIfUndefined } from '@codelab/frontend/shared/utils'
-import { TypeBaseWhere } from '@codelab/shared/abstract/codegen'
+import { BaseTypeWhere } from '@codelab/shared/abstract/codegen'
 import {
   assertIsTypeKind,
   IPrimitiveTypeKind,
@@ -151,7 +152,7 @@ export class TypeService
 
   @modelFlow
   @transaction
-  getAll = _async(function* (this: TypeService, where?: TypeBaseWhere) {
+  getAll = _async(function* (this: TypeService, where?: BaseTypeWhere) {
     const ids = where?.id_IN ?? undefined
     // const idsToFetch = ids?.filter((id) => !this.types.has(id))
     const types = yield* _await(getAllTypes(ids))

--- a/libs/shared/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/shared/abstract/codegen/src/ogm-types.gen.ts
@@ -1933,9 +1933,13 @@ export enum CodeMirrorLanguage {
 }
 
 export enum ElementTypeKind {
+  /** Pick any element in the current tree */
   AllElements = 'AllElements',
-  ChildrenOnly = 'ChildrenOnly',
+  /** Pick any element from the descendants of the current element */
   DescendantsOnly = 'DescendantsOnly',
+  /** Pick any element from the children of the current element */
+  ChildrenOnly = 'ChildrenOnly',
+  /** Pick parents and siblings of parents of elements (used to move element) */
   ExcludeDescendantsElements = 'ExcludeDescendantsElements',
 }
 

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -106,14 +106,14 @@ export enum ActionKind {
 }
 
 /** Allows picking a action from the list of actions */
-export type ActionType = TypeBase & {
+export type ActionType = IBaseType & {
   __typename?: 'ActionType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<ActionTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /** Allows picking a action from the list of actions */
@@ -134,8 +134,8 @@ export type ActionTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type ActionTypeAggregateSelection = {
@@ -146,11 +146,11 @@ export type ActionTypeAggregateSelection = {
 }
 
 export type ActionTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type ActionTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type ActionTypeConnectOrCreateWhere = {
@@ -165,15 +165,15 @@ export type ActionTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type ActionTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type ActionTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type ActionTypeEdge = {
@@ -298,7 +298,7 @@ export type ActionTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type ActionTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort ActionTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActionTypeSort object. */
@@ -315,7 +315,7 @@ export type ActionTypeUniqueWhere = {
 export type ActionTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type ActionTypeUserOwnerAggregationSelection = {
@@ -367,8 +367,8 @@ export type ActionTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<ActionTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -1943,14 +1943,14 @@ export type AppStoreUpdateFieldInput = {
 }
 
 /** Allows picking a app from the list of apps */
-export type AppType = TypeBase & {
+export type AppType = IBaseType & {
   __typename?: 'AppType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<AppTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /** Allows picking a app from the list of apps */
@@ -1971,8 +1971,8 @@ export type AppTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type AppTypeAggregateSelection = {
@@ -1983,11 +1983,11 @@ export type AppTypeAggregateSelection = {
 }
 
 export type AppTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type AppTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type AppTypeConnectOrCreateWhere = {
@@ -2002,15 +2002,15 @@ export type AppTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type AppTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type AppTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type AppTypeEdge = {
@@ -2135,7 +2135,7 @@ export type AppTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type AppTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort AppTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one AppTypeSort object. */
@@ -2152,7 +2152,7 @@ export type AppTypeUniqueWhere = {
 export type AppTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type AppTypeUserOwnerAggregationSelection = {
@@ -2204,8 +2204,8 @@ export type AppTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<AppTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -2326,7 +2326,7 @@ export type AppsConnection = {
  * ArrayType Allows defining a variable number of items of a given type.
  * Contains a reference to another type which is the array item type.
  */
-export type ArrayType = TypeBase &
+export type ArrayType = IBaseType &
   WithDescendants & {
     __typename?: 'ArrayType'
     descendantTypesIds: Array<Scalars['ID']>
@@ -2337,7 +2337,7 @@ export type ArrayType = TypeBase &
     name: Scalars['String']
     owner: User
     ownerAggregate?: Maybe<ArrayTypeUserOwnerAggregationSelection>
-    ownerConnection: TypeBaseOwnerConnection
+    ownerConnection: IBaseTypeOwnerConnection
   }
 
 /**
@@ -2388,8 +2388,8 @@ export type ArrayTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type ArrayTypeAggregateSelection = {
@@ -2401,12 +2401,12 @@ export type ArrayTypeAggregateSelection = {
 
 export type ArrayTypeConnectInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeConnectInput>
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type ArrayTypeConnectOrCreateInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeConnectOrCreateInput>
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type ArrayTypeConnectOrCreateWhere = {
@@ -2422,17 +2422,17 @@ export type ArrayTypeCreateInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeCreateInput>
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type ArrayTypeDeleteInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeDeleteInput>
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type ArrayTypeDisconnectInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeDisconnectInput>
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type ArrayTypeEdge = {
@@ -3425,7 +3425,7 @@ export type ArrayTypeOwnerNodeAggregationWhereInput = {
 
 export type ArrayTypeRelationInput = {
   itemType?: InputMaybe<ArrayTypeItemTypeCreateFieldInput>
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort ArrayTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one ArrayTypeSort object. */
@@ -3443,7 +3443,7 @@ export type ArrayTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   itemType?: InputMaybe<ArrayTypeItemTypeUpdateInput>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type ArrayTypeUserOwnerAggregationSelection = {
@@ -3497,8 +3497,8 @@ export type ArrayTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<ArrayTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -4525,6 +4525,249 @@ export type AtomsConnection = {
   totalCount: Scalars['Int']
 }
 
+export type BaseType = IBaseType & {
+  __typename?: 'BaseType'
+  id: Scalars['ID']
+  kind: TypeKind
+  name: Scalars['String']
+  owner: User
+  ownerAggregate?: Maybe<BaseTypeUserOwnerAggregationSelection>
+  ownerConnection: IBaseTypeOwnerConnection
+}
+
+export type BaseTypeOwnerArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  options?: InputMaybe<UserOptions>
+  where?: InputMaybe<UserWhere>
+}
+
+export type BaseTypeOwnerAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<UserWhere>
+}
+
+export type BaseTypeOwnerConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  directed?: InputMaybe<Scalars['Boolean']>
+  first?: InputMaybe<Scalars['Int']>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+}
+
+export type BaseTypeConnectInput = {
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
+}
+
+export type BaseTypeConnectOrCreateWhere = {
+  node: BaseTypeUniqueWhere
+}
+
+export type BaseTypeConnectWhere = {
+  node: BaseTypeWhere
+}
+
+export type BaseTypeCreateInput = {
+  id: Scalars['ID']
+  kind: TypeKind
+  name: Scalars['String']
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
+}
+
+export type BaseTypeDeleteInput = {
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
+}
+
+export type BaseTypeDisconnectInput = {
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
+}
+
+export type BaseTypeOnCreateInput = {
+  id: Scalars['ID']
+  name: Scalars['String']
+}
+
+export type BaseTypeOptions = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  /** Specify one or more BaseTypeSort objects to sort BaseTypes by. The sorts will be applied in the order in which they are arranged in the array. */
+  sort?: InputMaybe<Array<BaseTypeSort>>
+}
+
+export type BaseTypeOwnerAggregateInput = {
+  AND?: InputMaybe<Array<BaseTypeOwnerAggregateInput>>
+  OR?: InputMaybe<Array<BaseTypeOwnerAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  edge?: InputMaybe<BaseTypeOwnerEdgeAggregationWhereInput>
+  node?: InputMaybe<BaseTypeOwnerNodeAggregationWhereInput>
+}
+
+export type BaseTypeOwnerEdgeAggregationWhereInput = {
+  AND?: InputMaybe<Array<BaseTypeOwnerEdgeAggregationWhereInput>>
+  OR?: InputMaybe<Array<BaseTypeOwnerEdgeAggregationWhereInput>>
+  data_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  data_EQUAL?: InputMaybe<Scalars['String']>
+  data_GT?: InputMaybe<Scalars['Int']>
+  data_GTE?: InputMaybe<Scalars['Int']>
+  data_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  data_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  data_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  data_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  data_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  data_LT?: InputMaybe<Scalars['Int']>
+  data_LTE?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+export type BaseTypeOwnerNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<BaseTypeOwnerNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<BaseTypeOwnerNodeAggregationWhereInput>>
+  auth0Id_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  auth0Id_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  auth0Id_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  auth0Id_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  auth0Id_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  auth0Id_EQUAL?: InputMaybe<Scalars['String']>
+  auth0Id_GT?: InputMaybe<Scalars['Int']>
+  auth0Id_GTE?: InputMaybe<Scalars['Int']>
+  auth0Id_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  auth0Id_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  auth0Id_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  auth0Id_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  auth0Id_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  auth0Id_LT?: InputMaybe<Scalars['Int']>
+  auth0Id_LTE?: InputMaybe<Scalars['Int']>
+  auth0Id_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  auth0Id_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  auth0Id_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  auth0Id_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  auth0Id_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  email_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  email_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  email_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  email_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  email_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  email_EQUAL?: InputMaybe<Scalars['String']>
+  email_GT?: InputMaybe<Scalars['Int']>
+  email_GTE?: InputMaybe<Scalars['Int']>
+  email_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  email_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  email_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  email_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  email_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  email_LT?: InputMaybe<Scalars['Int']>
+  email_LTE?: InputMaybe<Scalars['Int']>
+  email_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  email_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  email_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  email_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  email_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  username_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  username_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  username_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  username_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  username_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  username_EQUAL?: InputMaybe<Scalars['String']>
+  username_GT?: InputMaybe<Scalars['Int']>
+  username_GTE?: InputMaybe<Scalars['Int']>
+  username_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  username_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  username_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  username_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  username_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  username_LT?: InputMaybe<Scalars['Int']>
+  username_LTE?: InputMaybe<Scalars['Int']>
+  username_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  username_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  username_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  username_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  username_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+}
+
+/** Fields to sort BaseTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one BaseTypeSort object. */
+export type BaseTypeSort = {
+  id?: InputMaybe<SortDirection>
+  kind?: InputMaybe<SortDirection>
+  name?: InputMaybe<SortDirection>
+}
+
+export type BaseTypeUniqueWhere = {
+  id?: InputMaybe<Scalars['ID']>
+  name?: InputMaybe<Scalars['String']>
+}
+
+export type BaseTypeUpdateInput = {
+  id?: InputMaybe<Scalars['ID']>
+  name?: InputMaybe<Scalars['String']>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
+}
+
+export type BaseTypeUserOwnerAggregationSelection = {
+  __typename?: 'BaseTypeUserOwnerAggregationSelection'
+  count: Scalars['Int']
+  edge?: Maybe<BaseTypeUserOwnerEdgeAggregateSelection>
+  node?: Maybe<BaseTypeUserOwnerNodeAggregateSelection>
+}
+
+export type BaseTypeUserOwnerEdgeAggregateSelection = {
+  __typename?: 'BaseTypeUserOwnerEdgeAggregateSelection'
+  data: StringAggregateSelectionNonNullable
+}
+
+export type BaseTypeUserOwnerNodeAggregateSelection = {
+  __typename?: 'BaseTypeUserOwnerNodeAggregateSelection'
+  auth0Id: StringAggregateSelectionNonNullable
+  email: StringAggregateSelectionNonNullable
+  id: IdAggregateSelectionNonNullable
+  username: StringAggregateSelectionNonNullable
+}
+
+export type BaseTypeWhere = {
+  AND?: InputMaybe<Array<BaseTypeWhere>>
+  OR?: InputMaybe<Array<BaseTypeWhere>>
+  id?: InputMaybe<Scalars['ID']>
+  id_CONTAINS?: InputMaybe<Scalars['ID']>
+  id_ENDS_WITH?: InputMaybe<Scalars['ID']>
+  id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_NOT?: InputMaybe<Scalars['ID']>
+  id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
+  id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
+  id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
+  id_STARTS_WITH?: InputMaybe<Scalars['ID']>
+  kind?: InputMaybe<TypeKind>
+  kind_IN?: InputMaybe<Array<TypeKind>>
+  kind_NOT?: InputMaybe<TypeKind>
+  kind_NOT_IN?: InputMaybe<Array<TypeKind>>
+  name?: InputMaybe<Scalars['String']>
+  name_CONTAINS?: InputMaybe<Scalars['String']>
+  name_ENDS_WITH?: InputMaybe<Scalars['String']>
+  name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_NOT?: InputMaybe<Scalars['String']>
+  name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
+  name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
+  name_STARTS_WITH?: InputMaybe<Scalars['String']>
+  owner?: InputMaybe<UserWhere>
+  ownerAggregate?: InputMaybe<BaseTypeOwnerAggregateInput>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  owner_NOT?: InputMaybe<UserWhere>
+}
+
 export type CodeAction = ActionBase & {
   __typename?: 'CodeAction'
   /** Code to run when action is triggered */
@@ -4748,7 +4991,7 @@ export enum CodeMirrorLanguage {
 }
 
 /** Allows editing the value using a code mirror editor */
-export type CodeMirrorType = TypeBase & {
+export type CodeMirrorType = IBaseType & {
   __typename?: 'CodeMirrorType'
   id: Scalars['ID']
   kind: TypeKind
@@ -4756,7 +4999,7 @@ export type CodeMirrorType = TypeBase & {
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<CodeMirrorTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /** Allows editing the value using a code mirror editor */
@@ -4777,8 +5020,8 @@ export type CodeMirrorTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type CodeMirrorTypeAggregateSelection = {
@@ -4789,11 +5032,11 @@ export type CodeMirrorTypeAggregateSelection = {
 }
 
 export type CodeMirrorTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type CodeMirrorTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type CodeMirrorTypeConnectOrCreateWhere = {
@@ -4809,15 +5052,15 @@ export type CodeMirrorTypeCreateInput = {
   kind?: TypeKind
   language: CodeMirrorLanguage
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type CodeMirrorTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type CodeMirrorTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type CodeMirrorTypeEdge = {
@@ -4942,7 +5185,7 @@ export type CodeMirrorTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type CodeMirrorTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort CodeMirrorTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one CodeMirrorTypeSort object. */
@@ -4961,7 +5204,7 @@ export type CodeMirrorTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   language?: InputMaybe<CodeMirrorLanguage>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type CodeMirrorTypeUserOwnerAggregationSelection = {
@@ -5017,8 +5260,8 @@ export type CodeMirrorTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<CodeMirrorTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -5816,6 +6059,12 @@ export type CreateEnumTypeValuesMutationResponse = {
 export type CreateEnumTypesMutationResponse = {
   __typename?: 'CreateEnumTypesMutationResponse'
   enumTypes: Array<EnumType>
+  info: CreateInfo
+}
+
+export type CreateGetBaseTypesReturnsMutationResponse = {
+  __typename?: 'CreateGetBaseTypesReturnsMutationResponse'
+  getBaseTypesReturns: Array<GetBaseTypesReturn>
   info: CreateInfo
 }
 
@@ -8780,7 +9029,7 @@ export type ElementSort = {
  * - ReactNodeType: Component select box, results it 'ReactNode' value
  * - ElementType: Current tree element select box, results it 'ReactNode' value
  */
-export type ElementType = TypeBase & {
+export type ElementType = IBaseType & {
   __typename?: 'ElementType'
   /** Allows scoping the type of element to only descendants, children or all elements */
   elementKind: ElementTypeKind
@@ -8789,7 +9038,7 @@ export type ElementType = TypeBase & {
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<ElementTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /**
@@ -8837,8 +9086,8 @@ export type ElementTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type ElementTypeAggregateSelection = {
@@ -8849,11 +9098,11 @@ export type ElementTypeAggregateSelection = {
 }
 
 export type ElementTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type ElementTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type ElementTypeConnectOrCreateWhere = {
@@ -8869,15 +9118,15 @@ export type ElementTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type ElementTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type ElementTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type ElementTypeEdge = {
@@ -9009,7 +9258,7 @@ export type ElementTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type ElementTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort ElementTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one ElementTypeSort object. */
@@ -9028,7 +9277,7 @@ export type ElementTypeUpdateInput = {
   elementKind?: InputMaybe<ElementTypeKind>
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type ElementTypeUserOwnerAggregationSelection = {
@@ -9084,8 +9333,8 @@ export type ElementTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<ElementTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -9301,7 +9550,7 @@ export type ElementsConnection = {
  * The value gets passed to the render pipe as a Enum Type Value id.
  * The actual value must be de-referenced by the id.
  */
-export type EnumType = TypeBase & {
+export type EnumType = IBaseType & {
   __typename?: 'EnumType'
   allowedValues: Array<EnumTypeValue>
   allowedValuesAggregate?: Maybe<EnumTypeEnumTypeValueAllowedValuesAggregationSelection>
@@ -9311,7 +9560,7 @@ export type EnumType = TypeBase & {
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<EnumTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /**
@@ -9378,8 +9627,8 @@ export type EnumTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type EnumTypeAggregateSelection = {
@@ -9509,11 +9758,11 @@ export type EnumTypeAllowedValuesUpdateFieldInput = {
 
 export type EnumTypeConnectInput = {
   allowedValues?: InputMaybe<Array<EnumTypeAllowedValuesConnectFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type EnumTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type EnumTypeConnectOrCreateWhere = {
@@ -9529,17 +9778,17 @@ export type EnumTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type EnumTypeDeleteInput = {
   allowedValues?: InputMaybe<Array<EnumTypeAllowedValuesDeleteFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type EnumTypeDisconnectInput = {
   allowedValues?: InputMaybe<Array<EnumTypeAllowedValuesDisconnectFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type EnumTypeEdge = {
@@ -9678,7 +9927,7 @@ export type EnumTypeOwnerNodeAggregationWhereInput = {
 
 export type EnumTypeRelationInput = {
   allowedValues?: InputMaybe<Array<EnumTypeAllowedValuesCreateFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort EnumTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one EnumTypeSort object. */
@@ -9696,7 +9945,7 @@ export type EnumTypeUpdateInput = {
   allowedValues?: InputMaybe<Array<EnumTypeAllowedValuesUpdateFieldInput>>
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type EnumTypeUserOwnerAggregationSelection = {
@@ -10024,8 +10273,8 @@ export type EnumTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<EnumTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -10121,6 +10370,71 @@ export type FieldWhere = {
   validationRules_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   validationRules_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   validationRules_STARTS_WITH?: InputMaybe<Scalars['String']>
+}
+
+export type GetBaseTypesOptions = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+}
+
+export type GetBaseTypesReturn = {
+  __typename?: 'GetBaseTypesReturn'
+  items: Array<BaseType>
+  totalCount: Scalars['Int']
+}
+
+export type GetBaseTypesReturnAggregateSelection = {
+  __typename?: 'GetBaseTypesReturnAggregateSelection'
+  count: Scalars['Int']
+  totalCount: IntAggregateSelectionNonNullable
+}
+
+export type GetBaseTypesReturnCreateInput = {
+  totalCount: Scalars['Int']
+}
+
+export type GetBaseTypesReturnEdge = {
+  __typename?: 'GetBaseTypesReturnEdge'
+  cursor: Scalars['String']
+  node: GetBaseTypesReturn
+}
+
+export type GetBaseTypesReturnOptions = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  /** Specify one or more GetBaseTypesReturnSort objects to sort GetBaseTypesReturns by. The sorts will be applied in the order in which they are arranged in the array. */
+  sort?: InputMaybe<Array<GetBaseTypesReturnSort>>
+}
+
+/** Fields to sort GetBaseTypesReturns by. The order in which sorts are applied is not guaranteed when specifying many fields in one GetBaseTypesReturnSort object. */
+export type GetBaseTypesReturnSort = {
+  totalCount?: InputMaybe<SortDirection>
+}
+
+export type GetBaseTypesReturnUpdateInput = {
+  totalCount?: InputMaybe<Scalars['Int']>
+  totalCount_DECREMENT?: InputMaybe<Scalars['Int']>
+  totalCount_INCREMENT?: InputMaybe<Scalars['Int']>
+}
+
+export type GetBaseTypesReturnWhere = {
+  AND?: InputMaybe<Array<GetBaseTypesReturnWhere>>
+  OR?: InputMaybe<Array<GetBaseTypesReturnWhere>>
+  totalCount?: InputMaybe<Scalars['Int']>
+  totalCount_GT?: InputMaybe<Scalars['Int']>
+  totalCount_GTE?: InputMaybe<Scalars['Int']>
+  totalCount_IN?: InputMaybe<Array<Scalars['Int']>>
+  totalCount_LT?: InputMaybe<Scalars['Int']>
+  totalCount_LTE?: InputMaybe<Scalars['Int']>
+  totalCount_NOT?: InputMaybe<Scalars['Int']>
+  totalCount_NOT_IN?: InputMaybe<Array<Scalars['Int']>>
+}
+
+export type GetBaseTypesReturnsConnection = {
+  __typename?: 'GetBaseTypesReturnsConnection'
+  edges: Array<GetBaseTypesReturnEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
 }
 
 export type Hook = {
@@ -10674,6 +10988,94 @@ export type HooksConnection = {
   totalCount: Scalars['Int']
 }
 
+export type IBaseType = {
+  id: Scalars['ID']
+  kind: TypeKind
+  name: Scalars['String']
+  owner: User
+  ownerConnection: IBaseTypeOwnerConnection
+}
+
+export type IBaseTypeOwnerConnectFieldInput = {
+  connect?: InputMaybe<UserConnectInput>
+  edge: OwnedByCreateInput
+  where?: InputMaybe<UserConnectWhere>
+}
+
+export type IBaseTypeOwnerConnectOrCreateFieldInput = {
+  onCreate: IBaseTypeOwnerConnectOrCreateFieldInputOnCreate
+  where: UserConnectOrCreateWhere
+}
+
+export type IBaseTypeOwnerConnectOrCreateFieldInputOnCreate = {
+  edge: OwnedByCreateInput
+  node: UserOnCreateInput
+}
+
+export type IBaseTypeOwnerConnection = {
+  __typename?: 'IBaseTypeOwnerConnection'
+  edges: Array<IBaseTypeOwnerRelationship>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type IBaseTypeOwnerConnectionSort = {
+  edge?: InputMaybe<OwnedBySort>
+  node?: InputMaybe<UserSort>
+}
+
+export type IBaseTypeOwnerConnectionWhere = {
+  AND?: InputMaybe<Array<IBaseTypeOwnerConnectionWhere>>
+  OR?: InputMaybe<Array<IBaseTypeOwnerConnectionWhere>>
+  edge?: InputMaybe<OwnedByWhere>
+  edge_NOT?: InputMaybe<OwnedByWhere>
+  node?: InputMaybe<UserWhere>
+  node_NOT?: InputMaybe<UserWhere>
+}
+
+export type IBaseTypeOwnerCreateFieldInput = {
+  edge: OwnedByCreateInput
+  node: UserCreateInput
+}
+
+export type IBaseTypeOwnerDeleteFieldInput = {
+  delete?: InputMaybe<UserDeleteInput>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+}
+
+export type IBaseTypeOwnerDisconnectFieldInput = {
+  disconnect?: InputMaybe<UserDisconnectInput>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+}
+
+export type IBaseTypeOwnerFieldInput = {
+  connect?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
+  connectOrCreate?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
+  create?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
+}
+
+export type IBaseTypeOwnerRelationship = OwnedBy & {
+  __typename?: 'IBaseTypeOwnerRelationship'
+  cursor: Scalars['String']
+  data: Scalars['String']
+  node: User
+}
+
+export type IBaseTypeOwnerUpdateConnectionInput = {
+  edge?: InputMaybe<OwnedByUpdateInput>
+  node?: InputMaybe<UserUpdateInput>
+}
+
+export type IBaseTypeOwnerUpdateFieldInput = {
+  connect?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
+  connectOrCreate?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
+  create?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
+  delete?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
+  disconnect?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
+  update?: InputMaybe<IBaseTypeOwnerUpdateConnectionInput>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+}
+
 export type IdAggregateSelectionNonNullable = {
   __typename?: 'IDAggregateSelectionNonNullable'
   longest: Scalars['ID']
@@ -10689,22 +11091,23 @@ export type IntAggregateSelectionNonNullable = {
 }
 
 /** Represents an object type with multiple fields */
-export type InterfaceType = TypeBase &
+export type InterfaceType = IBaseType &
   WithDescendants & {
     __typename?: 'InterfaceType'
     apiOfAtoms: Array<Atom>
     apiOfAtomsAggregate?: Maybe<InterfaceTypeAtomApiOfAtomsAggregationSelection>
     apiOfAtomsConnection: InterfaceTypeApiOfAtomsConnection
     descendantTypesIds: Array<Scalars['ID']>
-    fieldFor: Array<TypeBase>
-    fields: Array<TypeBase>
+    fieldFor: Array<BaseType>
+    fields: Array<BaseType>
+    fieldsAggregate?: Maybe<InterfaceTypeBaseTypeFieldsAggregationSelection>
     fieldsConnection: InterfaceTypeFieldsConnection
     id: Scalars['ID']
     kind: TypeKind
     name: Scalars['String']
     owner: User
     ownerAggregate?: Maybe<InterfaceTypeUserOwnerAggregationSelection>
-    ownerConnection: TypeBaseOwnerConnection
+    ownerConnection: IBaseTypeOwnerConnection
   }
 
 /** Represents an object type with multiple fields */
@@ -10732,8 +11135,14 @@ export type InterfaceTypeApiOfAtomsConnectionArgs = {
 /** Represents an object type with multiple fields */
 export type InterfaceTypeFieldsArgs = {
   directed?: InputMaybe<Scalars['Boolean']>
-  options?: InputMaybe<TypeBaseOptions>
-  where?: InputMaybe<TypeBaseWhere>
+  options?: InputMaybe<BaseTypeOptions>
+  where?: InputMaybe<BaseTypeWhere>
+}
+
+/** Represents an object type with multiple fields */
+export type InterfaceTypeFieldsAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<BaseTypeWhere>
 }
 
 /** Represents an object type with multiple fields */
@@ -10763,8 +11172,8 @@ export type InterfaceTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type InterfaceTypeAggregateSelection = {
@@ -10920,17 +11329,40 @@ export type InterfaceTypeAtomApiOfAtomsNodeAggregateSelection = {
   name: StringAggregateSelectionNonNullable
 }
 
+export type InterfaceTypeBaseTypeFieldsAggregationSelection = {
+  __typename?: 'InterfaceTypeBaseTypeFieldsAggregationSelection'
+  count: Scalars['Int']
+  edge?: Maybe<InterfaceTypeBaseTypeFieldsEdgeAggregateSelection>
+  node?: Maybe<InterfaceTypeBaseTypeFieldsNodeAggregateSelection>
+}
+
+export type InterfaceTypeBaseTypeFieldsEdgeAggregateSelection = {
+  __typename?: 'InterfaceTypeBaseTypeFieldsEdgeAggregateSelection'
+  description: StringAggregateSelectionNullable
+  id: IdAggregateSelectionNonNullable
+  key: StringAggregateSelectionNonNullable
+  name: StringAggregateSelectionNullable
+  validationRules: StringAggregateSelectionNullable
+}
+
+export type InterfaceTypeBaseTypeFieldsNodeAggregateSelection = {
+  __typename?: 'InterfaceTypeBaseTypeFieldsNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
+}
+
 export type InterfaceTypeConnectInput = {
   apiOfAtoms?: InputMaybe<Array<InterfaceTypeApiOfAtomsConnectFieldInput>>
   fields?: InputMaybe<Array<InterfaceTypeFieldsConnectFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type InterfaceTypeConnectOrCreateInput = {
   apiOfAtoms?: InputMaybe<
     Array<InterfaceTypeApiOfAtomsConnectOrCreateFieldInput>
   >
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  fields?: InputMaybe<Array<InterfaceTypeFieldsConnectOrCreateFieldInput>>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type InterfaceTypeConnectOrCreateWhere = {
@@ -10947,19 +11379,19 @@ export type InterfaceTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type InterfaceTypeDeleteInput = {
   apiOfAtoms?: InputMaybe<Array<InterfaceTypeApiOfAtomsDeleteFieldInput>>
   fields?: InputMaybe<Array<InterfaceTypeFieldsDeleteFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type InterfaceTypeDisconnectInput = {
   apiOfAtoms?: InputMaybe<Array<InterfaceTypeApiOfAtomsDisconnectFieldInput>>
   fields?: InputMaybe<Array<InterfaceTypeFieldsDisconnectFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type InterfaceTypeEdge = {
@@ -10968,10 +11400,32 @@ export type InterfaceTypeEdge = {
   node: InterfaceType
 }
 
+export type InterfaceTypeFieldsAggregateInput = {
+  AND?: InputMaybe<Array<InterfaceTypeFieldsAggregateInput>>
+  OR?: InputMaybe<Array<InterfaceTypeFieldsAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  edge?: InputMaybe<InterfaceTypeFieldsEdgeAggregationWhereInput>
+  node?: InputMaybe<InterfaceTypeFieldsNodeAggregationWhereInput>
+}
+
 export type InterfaceTypeFieldsConnectFieldInput = {
-  connect?: InputMaybe<TypeBaseConnectInput>
+  connect?: InputMaybe<Array<BaseTypeConnectInput>>
   edge: FieldCreateInput
-  where?: InputMaybe<TypeBaseConnectWhere>
+  where?: InputMaybe<BaseTypeConnectWhere>
+}
+
+export type InterfaceTypeFieldsConnectOrCreateFieldInput = {
+  onCreate: InterfaceTypeFieldsConnectOrCreateFieldInputOnCreate
+  where: BaseTypeConnectOrCreateWhere
+}
+
+export type InterfaceTypeFieldsConnectOrCreateFieldInputOnCreate = {
+  edge: FieldCreateInput
+  node: BaseTypeOnCreateInput
 }
 
 export type InterfaceTypeFieldsConnection = {
@@ -10983,7 +11437,7 @@ export type InterfaceTypeFieldsConnection = {
 
 export type InterfaceTypeFieldsConnectionSort = {
   edge?: InputMaybe<FieldSort>
-  node?: InputMaybe<TypeBaseSort>
+  node?: InputMaybe<BaseTypeSort>
 }
 
 export type InterfaceTypeFieldsConnectionWhere = {
@@ -10991,28 +11445,143 @@ export type InterfaceTypeFieldsConnectionWhere = {
   OR?: InputMaybe<Array<InterfaceTypeFieldsConnectionWhere>>
   edge?: InputMaybe<FieldWhere>
   edge_NOT?: InputMaybe<FieldWhere>
-  node?: InputMaybe<TypeBaseWhere>
-  node_NOT?: InputMaybe<TypeBaseWhere>
+  node?: InputMaybe<BaseTypeWhere>
+  node_NOT?: InputMaybe<BaseTypeWhere>
 }
 
 export type InterfaceTypeFieldsCreateFieldInput = {
   edge: FieldCreateInput
-  node: TypeBaseCreateInput
+  node: BaseTypeCreateInput
 }
 
 export type InterfaceTypeFieldsDeleteFieldInput = {
-  delete?: InputMaybe<TypeBaseDeleteInput>
+  delete?: InputMaybe<BaseTypeDeleteInput>
   where?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
 }
 
 export type InterfaceTypeFieldsDisconnectFieldInput = {
-  disconnect?: InputMaybe<TypeBaseDisconnectInput>
+  disconnect?: InputMaybe<BaseTypeDisconnectInput>
   where?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
+}
+
+export type InterfaceTypeFieldsEdgeAggregationWhereInput = {
+  AND?: InputMaybe<Array<InterfaceTypeFieldsEdgeAggregationWhereInput>>
+  OR?: InputMaybe<Array<InterfaceTypeFieldsEdgeAggregationWhereInput>>
+  description_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  description_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  description_EQUAL?: InputMaybe<Scalars['String']>
+  description_GT?: InputMaybe<Scalars['Int']>
+  description_GTE?: InputMaybe<Scalars['Int']>
+  description_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  description_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  description_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  description_LT?: InputMaybe<Scalars['Int']>
+  description_LTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  description_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  key_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  key_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  key_EQUAL?: InputMaybe<Scalars['String']>
+  key_GT?: InputMaybe<Scalars['Int']>
+  key_GTE?: InputMaybe<Scalars['Int']>
+  key_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  key_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  key_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  key_LT?: InputMaybe<Scalars['Int']>
+  key_LTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  key_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  validationRules_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  validationRules_EQUAL?: InputMaybe<Scalars['String']>
+  validationRules_GT?: InputMaybe<Scalars['Int']>
+  validationRules_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  validationRules_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_LT?: InputMaybe<Scalars['Int']>
+  validationRules_LTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  validationRules_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type InterfaceTypeFieldsFieldInput = {
   connect?: InputMaybe<Array<InterfaceTypeFieldsConnectFieldInput>>
+  connectOrCreate?: InputMaybe<
+    Array<InterfaceTypeFieldsConnectOrCreateFieldInput>
+  >
   create?: InputMaybe<Array<InterfaceTypeFieldsCreateFieldInput>>
+}
+
+export type InterfaceTypeFieldsNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<InterfaceTypeFieldsNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<InterfaceTypeFieldsNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type InterfaceTypeFieldsRelationship = Field & {
@@ -11022,17 +11591,20 @@ export type InterfaceTypeFieldsRelationship = Field & {
   id: Scalars['ID']
   key: Scalars['String']
   name?: Maybe<Scalars['String']>
-  node: TypeBase
+  node: BaseType
   validationRules?: Maybe<Scalars['String']>
 }
 
 export type InterfaceTypeFieldsUpdateConnectionInput = {
   edge?: InputMaybe<FieldUpdateInput>
-  node?: InputMaybe<TypeBaseUpdateInput>
+  node?: InputMaybe<BaseTypeUpdateInput>
 }
 
 export type InterfaceTypeFieldsUpdateFieldInput = {
   connect?: InputMaybe<Array<InterfaceTypeFieldsConnectFieldInput>>
+  connectOrCreate?: InputMaybe<
+    Array<InterfaceTypeFieldsConnectOrCreateFieldInput>
+  >
   create?: InputMaybe<Array<InterfaceTypeFieldsCreateFieldInput>>
   delete?: InputMaybe<Array<InterfaceTypeFieldsDeleteFieldInput>>
   disconnect?: InputMaybe<Array<InterfaceTypeFieldsDisconnectFieldInput>>
@@ -11158,7 +11730,7 @@ export type InterfaceTypeOwnerNodeAggregationWhereInput = {
 export type InterfaceTypeRelationInput = {
   apiOfAtoms?: InputMaybe<Array<InterfaceTypeApiOfAtomsCreateFieldInput>>
   fields?: InputMaybe<Array<InterfaceTypeFieldsCreateFieldInput>>
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort InterfaceTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one InterfaceTypeSort object. */
@@ -11177,7 +11749,7 @@ export type InterfaceTypeUpdateInput = {
   fields?: InputMaybe<Array<InterfaceTypeFieldsUpdateFieldInput>>
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type InterfaceTypeUserOwnerAggregationSelection = {
@@ -11216,10 +11788,19 @@ export type InterfaceTypeWhere = {
   apiOfAtoms_SINGLE?: InputMaybe<AtomWhere>
   /** Return InterfaceTypes where some of the related Atoms match this filter */
   apiOfAtoms_SOME?: InputMaybe<AtomWhere>
+  fieldsAggregate?: InputMaybe<InterfaceTypeFieldsAggregateInput>
   fieldsConnection_ALL?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
   fieldsConnection_NONE?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
   fieldsConnection_SINGLE?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
   fieldsConnection_SOME?: InputMaybe<InterfaceTypeFieldsConnectionWhere>
+  /** Return InterfaceTypes where all of the related BaseTypes match this filter */
+  fields_ALL?: InputMaybe<BaseTypeWhere>
+  /** Return InterfaceTypes where none of the related BaseTypes match this filter */
+  fields_NONE?: InputMaybe<BaseTypeWhere>
+  /** Return InterfaceTypes where one of the related BaseTypes match this filter */
+  fields_SINGLE?: InputMaybe<BaseTypeWhere>
+  /** Return InterfaceTypes where some of the related BaseTypes match this filter */
+  fields_SOME?: InputMaybe<BaseTypeWhere>
   id?: InputMaybe<Scalars['ID']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -11246,8 +11827,8 @@ export type InterfaceTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<InterfaceTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -11259,14 +11840,14 @@ export type InterfaceTypesConnection = {
 }
 
 /** Allows picking a lambda */
-export type LambdaType = TypeBase & {
+export type LambdaType = IBaseType & {
   __typename?: 'LambdaType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<LambdaTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /** Allows picking a lambda */
@@ -11287,8 +11868,8 @@ export type LambdaTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type LambdaTypeAggregateSelection = {
@@ -11299,11 +11880,11 @@ export type LambdaTypeAggregateSelection = {
 }
 
 export type LambdaTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type LambdaTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type LambdaTypeConnectOrCreateWhere = {
@@ -11318,15 +11899,15 @@ export type LambdaTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type LambdaTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type LambdaTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type LambdaTypeEdge = {
@@ -11451,7 +12032,7 @@ export type LambdaTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type LambdaTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort LambdaTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one LambdaTypeSort object. */
@@ -11468,7 +12049,7 @@ export type LambdaTypeUniqueWhere = {
 export type LambdaTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type LambdaTypeUserOwnerAggregationSelection = {
@@ -11520,8 +12101,8 @@ export type LambdaTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<LambdaTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -11551,6 +12132,7 @@ export type Mutation = {
   createElements: CreateElementsMutationResponse
   createEnumTypeValues: CreateEnumTypeValuesMutationResponse
   createEnumTypes: CreateEnumTypesMutationResponse
+  createGetBaseTypesReturns: CreateGetBaseTypesReturnsMutationResponse
   createHooks: CreateHooksMutationResponse
   createInterfaceTypes: CreateInterfaceTypesMutationResponse
   createLambdaTypes: CreateLambdaTypesMutationResponse
@@ -11587,6 +12169,7 @@ export type Mutation = {
   deleteElements: DeleteInfo
   deleteEnumTypeValues: DeleteInfo
   deleteEnumTypes: DeleteInfo
+  deleteGetBaseTypesReturns: DeleteInfo
   deleteHooks: DeleteInfo
   deleteInterfaceTypes: DeleteInfo
   deleteLambdaTypes: DeleteInfo
@@ -11624,6 +12207,7 @@ export type Mutation = {
   updateElements: UpdateElementsMutationResponse
   updateEnumTypeValues: UpdateEnumTypeValuesMutationResponse
   updateEnumTypes: UpdateEnumTypesMutationResponse
+  updateGetBaseTypesReturns: UpdateGetBaseTypesReturnsMutationResponse
   updateHooks: UpdateHooksMutationResponse
   updateInterfaceTypes: UpdateInterfaceTypesMutationResponse
   updateLambdaTypes: UpdateLambdaTypesMutationResponse
@@ -11711,6 +12295,10 @@ export type MutationCreateEnumTypeValuesArgs = {
 
 export type MutationCreateEnumTypesArgs = {
   input: Array<EnumTypeCreateInput>
+}
+
+export type MutationCreateGetBaseTypesReturnsArgs = {
+  input: Array<GetBaseTypesReturnCreateInput>
 }
 
 export type MutationCreateHooksArgs = {
@@ -11869,6 +12457,10 @@ export type MutationDeleteEnumTypeValuesArgs = {
 export type MutationDeleteEnumTypesArgs = {
   delete?: InputMaybe<EnumTypeDeleteInput>
   where?: InputMaybe<EnumTypeWhere>
+}
+
+export type MutationDeleteGetBaseTypesReturnsArgs = {
+  where?: InputMaybe<GetBaseTypesReturnWhere>
 }
 
 export type MutationDeleteHooksArgs = {
@@ -12113,6 +12705,11 @@ export type MutationUpdateEnumTypesArgs = {
   disconnect?: InputMaybe<EnumTypeDisconnectInput>
   update?: InputMaybe<EnumTypeUpdateInput>
   where?: InputMaybe<EnumTypeWhere>
+}
+
+export type MutationUpdateGetBaseTypesReturnsArgs = {
+  update?: InputMaybe<GetBaseTypesReturnUpdateInput>
+  where?: InputMaybe<GetBaseTypesReturnWhere>
 }
 
 export type MutationUpdateHooksArgs = {
@@ -12853,14 +13450,14 @@ export type PageSort = {
 }
 
 /** Allows picking a page from the list of pages */
-export type PageType = TypeBase & {
+export type PageType = IBaseType & {
   __typename?: 'PageType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<PageTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /** Allows picking a page from the list of pages */
@@ -12881,8 +13478,8 @@ export type PageTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type PageTypeAggregateSelection = {
@@ -12893,11 +13490,11 @@ export type PageTypeAggregateSelection = {
 }
 
 export type PageTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type PageTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type PageTypeConnectOrCreateWhere = {
@@ -12912,15 +13509,15 @@ export type PageTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type PageTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type PageTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type PageTypeEdge = {
@@ -13045,7 +13642,7 @@ export type PageTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type PageTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort PageTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one PageTypeSort object. */
@@ -13062,7 +13659,7 @@ export type PageTypeUniqueWhere = {
 export type PageTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type PageTypeUserOwnerAggregationSelection = {
@@ -13114,8 +13711,8 @@ export type PageTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<PageTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -13191,14 +13788,14 @@ export type PagesConnection = {
 }
 
 /** Base atomic building block of the type system. Represents primitive types - String, Integer, Float, Boolean */
-export type PrimitiveType = TypeBase & {
+export type PrimitiveType = IBaseType & {
   __typename?: 'PrimitiveType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<PrimitiveTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
   primitiveKind: PrimitiveTypeKind
 }
 
@@ -13220,8 +13817,8 @@ export type PrimitiveTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type PrimitiveTypeAggregateSelection = {
@@ -13232,11 +13829,11 @@ export type PrimitiveTypeAggregateSelection = {
 }
 
 export type PrimitiveTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type PrimitiveTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type PrimitiveTypeConnectOrCreateWhere = {
@@ -13251,16 +13848,16 @@ export type PrimitiveTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
   primitiveKind: PrimitiveTypeKind
 }
 
 export type PrimitiveTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type PrimitiveTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type PrimitiveTypeEdge = {
@@ -13392,7 +13989,7 @@ export type PrimitiveTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type PrimitiveTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort PrimitiveTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one PrimitiveTypeSort object. */
@@ -13412,7 +14009,7 @@ export type PrimitiveTypeUniqueWhere = {
 export type PrimitiveTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
   primitiveKind?: InputMaybe<PrimitiveTypeKind>
 }
 
@@ -13465,8 +14062,8 @@ export type PrimitiveTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<PrimitiveTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
   primitiveKind?: InputMaybe<PrimitiveTypeKind>
   primitiveKind_IN?: InputMaybe<Array<PrimitiveTypeKind>>
@@ -14312,6 +14909,7 @@ export type Query = {
   atoms: Array<Atom>
   atomsAggregate: AtomAggregateSelection
   atomsConnection: AtomsConnection
+  baseTypes: GetBaseTypesReturn
   codeActions: Array<CodeAction>
   codeActionsAggregate: CodeActionAggregateSelection
   codeActionsConnection: CodeActionsConnection
@@ -14342,6 +14940,9 @@ export type Query = {
   enumTypes: Array<EnumType>
   enumTypesAggregate: EnumTypeAggregateSelection
   enumTypesConnection: EnumTypesConnection
+  getBaseTypesReturns: Array<GetBaseTypesReturn>
+  getBaseTypesReturnsAggregate: GetBaseTypesReturnAggregateSelection
+  getBaseTypesReturnsConnection: GetBaseTypesReturnsConnection
   /**
    * Returns a list of all Type and Atom entities that reference the type with the given id
    * This could be different types of relationships like Atom-Api, ArrayType-itemType, InterfaceType-field, UnionType-unionTypeChild
@@ -14504,6 +15105,10 @@ export type QueryAtomsConnectionArgs = {
   where?: InputMaybe<AtomWhere>
 }
 
+export type QueryBaseTypesArgs = {
+  options?: InputMaybe<GetBaseTypesOptions>
+}
+
 export type QueryCodeActionsArgs = {
   options?: InputMaybe<CodeActionOptions>
   where?: InputMaybe<CodeActionWhere>
@@ -14662,6 +15267,22 @@ export type QueryEnumTypesConnectionArgs = {
   first?: InputMaybe<Scalars['Int']>
   sort?: InputMaybe<Array<InputMaybe<EnumTypeSort>>>
   where?: InputMaybe<EnumTypeWhere>
+}
+
+export type QueryGetBaseTypesReturnsArgs = {
+  options?: InputMaybe<GetBaseTypesReturnOptions>
+  where?: InputMaybe<GetBaseTypesReturnWhere>
+}
+
+export type QueryGetBaseTypesReturnsAggregateArgs = {
+  where?: InputMaybe<GetBaseTypesReturnWhere>
+}
+
+export type QueryGetBaseTypesReturnsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  sort?: InputMaybe<Array<InputMaybe<GetBaseTypesReturnSort>>>
+  where?: InputMaybe<GetBaseTypesReturnWhere>
 }
 
 export type QueryGetTypeReferencesArgs = {
@@ -14992,14 +15613,14 @@ export type QueryOptions = {
  * - ReactNodeType: Component select box, results it 'ReactNode' value
  * - ElementType: Current tree element select box, results it 'ReactNode' value
  */
-export type ReactNodeType = TypeBase & {
+export type ReactNodeType = IBaseType & {
   __typename?: 'ReactNodeType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<ReactNodeTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /**
@@ -15047,8 +15668,8 @@ export type ReactNodeTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type ReactNodeTypeAggregateSelection = {
@@ -15059,11 +15680,11 @@ export type ReactNodeTypeAggregateSelection = {
 }
 
 export type ReactNodeTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type ReactNodeTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type ReactNodeTypeConnectOrCreateWhere = {
@@ -15078,15 +15699,15 @@ export type ReactNodeTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type ReactNodeTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type ReactNodeTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type ReactNodeTypeEdge = {
@@ -15211,7 +15832,7 @@ export type ReactNodeTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type ReactNodeTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort ReactNodeTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one ReactNodeTypeSort object. */
@@ -15228,7 +15849,7 @@ export type ReactNodeTypeUniqueWhere = {
 export type ReactNodeTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type ReactNodeTypeUserOwnerAggregationSelection = {
@@ -15280,8 +15901,8 @@ export type ReactNodeTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<ReactNodeTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -15303,14 +15924,14 @@ export type ReactNodeTypesConnection = {
  * - ReactNodeType: Component select box, results it 'ReactNode' value
  * - ElementType: Current tree element select box, results it 'ReactNode' value
  */
-export type RenderPropsType = TypeBase & {
+export type RenderPropsType = IBaseType & {
   __typename?: 'RenderPropsType'
   id: Scalars['ID']
   kind: TypeKind
   name: Scalars['String']
   owner: User
   ownerAggregate?: Maybe<RenderPropsTypeUserOwnerAggregationSelection>
-  ownerConnection: TypeBaseOwnerConnection
+  ownerConnection: IBaseTypeOwnerConnection
 }
 
 /**
@@ -15361,8 +15982,8 @@ export type RenderPropsTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 export type RenderPropsTypeAggregateSelection = {
@@ -15373,11 +15994,11 @@ export type RenderPropsTypeAggregateSelection = {
 }
 
 export type RenderPropsTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
 }
 
 export type RenderPropsTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
 }
 
 export type RenderPropsTypeConnectOrCreateWhere = {
@@ -15392,15 +16013,15 @@ export type RenderPropsTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
 }
 
 export type RenderPropsTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
 }
 
 export type RenderPropsTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
 }
 
 export type RenderPropsTypeEdge = {
@@ -15525,7 +16146,7 @@ export type RenderPropsTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type RenderPropsTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
 }
 
 /** Fields to sort RenderPropsTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one RenderPropsTypeSort object. */
@@ -15542,7 +16163,7 @@ export type RenderPropsTypeUniqueWhere = {
 export type RenderPropsTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
 }
 
 export type RenderPropsTypeUserOwnerAggregationSelection = {
@@ -15594,8 +16215,8 @@ export type RenderPropsTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<RenderPropsTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
 }
 
@@ -17337,380 +17958,6 @@ export type TagsConnection = {
   totalCount: Scalars['Int']
 }
 
-export type TypeBase = {
-  id: Scalars['ID']
-  kind: TypeKind
-  name: Scalars['String']
-  owner: User
-  ownerConnection: TypeBaseOwnerConnection
-}
-
-export type TypeBaseOwnerArgs = {
-  directed?: InputMaybe<Scalars['Boolean']>
-  options?: InputMaybe<UserOptions>
-  where?: InputMaybe<UserWhere>
-}
-
-export type TypeBaseOwnerConnectionArgs = {
-  after?: InputMaybe<Scalars['String']>
-  directed?: InputMaybe<Scalars['Boolean']>
-  first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
-}
-
-export type TypeBaseConnectInput = {
-  _on?: InputMaybe<TypeBaseImplementationsConnectInput>
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
-}
-
-export type TypeBaseConnectWhere = {
-  node: TypeBaseWhere
-}
-
-export type TypeBaseCreateInput = {
-  ActionType?: InputMaybe<ActionTypeCreateInput>
-  AppType?: InputMaybe<AppTypeCreateInput>
-  ArrayType?: InputMaybe<ArrayTypeCreateInput>
-  CodeMirrorType?: InputMaybe<CodeMirrorTypeCreateInput>
-  ElementType?: InputMaybe<ElementTypeCreateInput>
-  EnumType?: InputMaybe<EnumTypeCreateInput>
-  InterfaceType?: InputMaybe<InterfaceTypeCreateInput>
-  LambdaType?: InputMaybe<LambdaTypeCreateInput>
-  PageType?: InputMaybe<PageTypeCreateInput>
-  PrimitiveType?: InputMaybe<PrimitiveTypeCreateInput>
-  ReactNodeType?: InputMaybe<ReactNodeTypeCreateInput>
-  RenderPropsType?: InputMaybe<RenderPropsTypeCreateInput>
-  UnionType?: InputMaybe<UnionTypeCreateInput>
-}
-
-export type TypeBaseDeleteInput = {
-  _on?: InputMaybe<TypeBaseImplementationsDeleteInput>
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
-}
-
-export type TypeBaseDisconnectInput = {
-  _on?: InputMaybe<TypeBaseImplementationsDisconnectInput>
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
-}
-
-export type TypeBaseImplementationsConnectInput = {
-  ActionType?: InputMaybe<Array<ActionTypeConnectInput>>
-  AppType?: InputMaybe<Array<AppTypeConnectInput>>
-  ArrayType?: InputMaybe<Array<ArrayTypeConnectInput>>
-  CodeMirrorType?: InputMaybe<Array<CodeMirrorTypeConnectInput>>
-  ElementType?: InputMaybe<Array<ElementTypeConnectInput>>
-  EnumType?: InputMaybe<Array<EnumTypeConnectInput>>
-  InterfaceType?: InputMaybe<Array<InterfaceTypeConnectInput>>
-  LambdaType?: InputMaybe<Array<LambdaTypeConnectInput>>
-  PageType?: InputMaybe<Array<PageTypeConnectInput>>
-  PrimitiveType?: InputMaybe<Array<PrimitiveTypeConnectInput>>
-  ReactNodeType?: InputMaybe<Array<ReactNodeTypeConnectInput>>
-  RenderPropsType?: InputMaybe<Array<RenderPropsTypeConnectInput>>
-  UnionType?: InputMaybe<Array<UnionTypeConnectInput>>
-}
-
-export type TypeBaseImplementationsDeleteInput = {
-  ActionType?: InputMaybe<Array<ActionTypeDeleteInput>>
-  AppType?: InputMaybe<Array<AppTypeDeleteInput>>
-  ArrayType?: InputMaybe<Array<ArrayTypeDeleteInput>>
-  CodeMirrorType?: InputMaybe<Array<CodeMirrorTypeDeleteInput>>
-  ElementType?: InputMaybe<Array<ElementTypeDeleteInput>>
-  EnumType?: InputMaybe<Array<EnumTypeDeleteInput>>
-  InterfaceType?: InputMaybe<Array<InterfaceTypeDeleteInput>>
-  LambdaType?: InputMaybe<Array<LambdaTypeDeleteInput>>
-  PageType?: InputMaybe<Array<PageTypeDeleteInput>>
-  PrimitiveType?: InputMaybe<Array<PrimitiveTypeDeleteInput>>
-  ReactNodeType?: InputMaybe<Array<ReactNodeTypeDeleteInput>>
-  RenderPropsType?: InputMaybe<Array<RenderPropsTypeDeleteInput>>
-  UnionType?: InputMaybe<Array<UnionTypeDeleteInput>>
-}
-
-export type TypeBaseImplementationsDisconnectInput = {
-  ActionType?: InputMaybe<Array<ActionTypeDisconnectInput>>
-  AppType?: InputMaybe<Array<AppTypeDisconnectInput>>
-  ArrayType?: InputMaybe<Array<ArrayTypeDisconnectInput>>
-  CodeMirrorType?: InputMaybe<Array<CodeMirrorTypeDisconnectInput>>
-  ElementType?: InputMaybe<Array<ElementTypeDisconnectInput>>
-  EnumType?: InputMaybe<Array<EnumTypeDisconnectInput>>
-  InterfaceType?: InputMaybe<Array<InterfaceTypeDisconnectInput>>
-  LambdaType?: InputMaybe<Array<LambdaTypeDisconnectInput>>
-  PageType?: InputMaybe<Array<PageTypeDisconnectInput>>
-  PrimitiveType?: InputMaybe<Array<PrimitiveTypeDisconnectInput>>
-  ReactNodeType?: InputMaybe<Array<ReactNodeTypeDisconnectInput>>
-  RenderPropsType?: InputMaybe<Array<RenderPropsTypeDisconnectInput>>
-  UnionType?: InputMaybe<Array<UnionTypeDisconnectInput>>
-}
-
-export type TypeBaseImplementationsUpdateInput = {
-  ActionType?: InputMaybe<ActionTypeUpdateInput>
-  AppType?: InputMaybe<AppTypeUpdateInput>
-  ArrayType?: InputMaybe<ArrayTypeUpdateInput>
-  CodeMirrorType?: InputMaybe<CodeMirrorTypeUpdateInput>
-  ElementType?: InputMaybe<ElementTypeUpdateInput>
-  EnumType?: InputMaybe<EnumTypeUpdateInput>
-  InterfaceType?: InputMaybe<InterfaceTypeUpdateInput>
-  LambdaType?: InputMaybe<LambdaTypeUpdateInput>
-  PageType?: InputMaybe<PageTypeUpdateInput>
-  PrimitiveType?: InputMaybe<PrimitiveTypeUpdateInput>
-  ReactNodeType?: InputMaybe<ReactNodeTypeUpdateInput>
-  RenderPropsType?: InputMaybe<RenderPropsTypeUpdateInput>
-  UnionType?: InputMaybe<UnionTypeUpdateInput>
-}
-
-export type TypeBaseImplementationsWhere = {
-  ActionType?: InputMaybe<ActionTypeWhere>
-  AppType?: InputMaybe<AppTypeWhere>
-  ArrayType?: InputMaybe<ArrayTypeWhere>
-  CodeMirrorType?: InputMaybe<CodeMirrorTypeWhere>
-  ElementType?: InputMaybe<ElementTypeWhere>
-  EnumType?: InputMaybe<EnumTypeWhere>
-  InterfaceType?: InputMaybe<InterfaceTypeWhere>
-  LambdaType?: InputMaybe<LambdaTypeWhere>
-  PageType?: InputMaybe<PageTypeWhere>
-  PrimitiveType?: InputMaybe<PrimitiveTypeWhere>
-  ReactNodeType?: InputMaybe<ReactNodeTypeWhere>
-  RenderPropsType?: InputMaybe<RenderPropsTypeWhere>
-  UnionType?: InputMaybe<UnionTypeWhere>
-}
-
-export type TypeBaseOptions = {
-  limit?: InputMaybe<Scalars['Int']>
-  offset?: InputMaybe<Scalars['Int']>
-  /** Specify one or more TypeBaseSort objects to sort TypeBases by. The sorts will be applied in the order in which they are arranged in the array. */
-  sort?: InputMaybe<Array<InputMaybe<TypeBaseSort>>>
-}
-
-export type TypeBaseOwnerAggregateInput = {
-  AND?: InputMaybe<Array<TypeBaseOwnerAggregateInput>>
-  OR?: InputMaybe<Array<TypeBaseOwnerAggregateInput>>
-  count?: InputMaybe<Scalars['Int']>
-  count_GT?: InputMaybe<Scalars['Int']>
-  count_GTE?: InputMaybe<Scalars['Int']>
-  count_LT?: InputMaybe<Scalars['Int']>
-  count_LTE?: InputMaybe<Scalars['Int']>
-  edge?: InputMaybe<TypeBaseOwnerEdgeAggregationWhereInput>
-  node?: InputMaybe<TypeBaseOwnerNodeAggregationWhereInput>
-}
-
-export type TypeBaseOwnerConnectFieldInput = {
-  connect?: InputMaybe<UserConnectInput>
-  edge: OwnedByCreateInput
-  where?: InputMaybe<UserConnectWhere>
-}
-
-export type TypeBaseOwnerConnectOrCreateFieldInput = {
-  onCreate: TypeBaseOwnerConnectOrCreateFieldInputOnCreate
-  where: UserConnectOrCreateWhere
-}
-
-export type TypeBaseOwnerConnectOrCreateFieldInputOnCreate = {
-  edge: OwnedByCreateInput
-  node: UserOnCreateInput
-}
-
-export type TypeBaseOwnerConnection = {
-  __typename?: 'TypeBaseOwnerConnection'
-  edges: Array<TypeBaseOwnerRelationship>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']
-}
-
-export type TypeBaseOwnerConnectionSort = {
-  edge?: InputMaybe<OwnedBySort>
-  node?: InputMaybe<UserSort>
-}
-
-export type TypeBaseOwnerConnectionWhere = {
-  AND?: InputMaybe<Array<TypeBaseOwnerConnectionWhere>>
-  OR?: InputMaybe<Array<TypeBaseOwnerConnectionWhere>>
-  edge?: InputMaybe<OwnedByWhere>
-  edge_NOT?: InputMaybe<OwnedByWhere>
-  node?: InputMaybe<UserWhere>
-  node_NOT?: InputMaybe<UserWhere>
-}
-
-export type TypeBaseOwnerCreateFieldInput = {
-  edge: OwnedByCreateInput
-  node: UserCreateInput
-}
-
-export type TypeBaseOwnerDeleteFieldInput = {
-  delete?: InputMaybe<UserDeleteInput>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
-}
-
-export type TypeBaseOwnerDisconnectFieldInput = {
-  disconnect?: InputMaybe<UserDisconnectInput>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
-}
-
-export type TypeBaseOwnerEdgeAggregationWhereInput = {
-  AND?: InputMaybe<Array<TypeBaseOwnerEdgeAggregationWhereInput>>
-  OR?: InputMaybe<Array<TypeBaseOwnerEdgeAggregationWhereInput>>
-  data_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  data_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  data_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  data_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  data_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  data_EQUAL?: InputMaybe<Scalars['String']>
-  data_GT?: InputMaybe<Scalars['Int']>
-  data_GTE?: InputMaybe<Scalars['Int']>
-  data_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  data_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  data_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  data_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  data_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  data_LT?: InputMaybe<Scalars['Int']>
-  data_LTE?: InputMaybe<Scalars['Int']>
-  data_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  data_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  data_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  data_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  data_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-}
-
-export type TypeBaseOwnerFieldInput = {
-  connect?: InputMaybe<TypeBaseOwnerConnectFieldInput>
-  connectOrCreate?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
-  create?: InputMaybe<TypeBaseOwnerCreateFieldInput>
-}
-
-export type TypeBaseOwnerNodeAggregationWhereInput = {
-  AND?: InputMaybe<Array<TypeBaseOwnerNodeAggregationWhereInput>>
-  OR?: InputMaybe<Array<TypeBaseOwnerNodeAggregationWhereInput>>
-  auth0Id_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  auth0Id_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  auth0Id_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  auth0Id_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  auth0Id_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  auth0Id_EQUAL?: InputMaybe<Scalars['String']>
-  auth0Id_GT?: InputMaybe<Scalars['Int']>
-  auth0Id_GTE?: InputMaybe<Scalars['Int']>
-  auth0Id_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  auth0Id_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  auth0Id_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  auth0Id_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  auth0Id_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  auth0Id_LT?: InputMaybe<Scalars['Int']>
-  auth0Id_LTE?: InputMaybe<Scalars['Int']>
-  auth0Id_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  auth0Id_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  auth0Id_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  auth0Id_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  auth0Id_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  email_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  email_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  email_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  email_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  email_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  email_EQUAL?: InputMaybe<Scalars['String']>
-  email_GT?: InputMaybe<Scalars['Int']>
-  email_GTE?: InputMaybe<Scalars['Int']>
-  email_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  email_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  email_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  email_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  email_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  email_LT?: InputMaybe<Scalars['Int']>
-  email_LTE?: InputMaybe<Scalars['Int']>
-  email_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  email_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  email_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  email_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  email_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-  id_EQUAL?: InputMaybe<Scalars['ID']>
-  username_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
-  username_AVERAGE_GT?: InputMaybe<Scalars['Float']>
-  username_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
-  username_AVERAGE_LT?: InputMaybe<Scalars['Float']>
-  username_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
-  username_EQUAL?: InputMaybe<Scalars['String']>
-  username_GT?: InputMaybe<Scalars['Int']>
-  username_GTE?: InputMaybe<Scalars['Int']>
-  username_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
-  username_LONGEST_GT?: InputMaybe<Scalars['Int']>
-  username_LONGEST_GTE?: InputMaybe<Scalars['Int']>
-  username_LONGEST_LT?: InputMaybe<Scalars['Int']>
-  username_LONGEST_LTE?: InputMaybe<Scalars['Int']>
-  username_LT?: InputMaybe<Scalars['Int']>
-  username_LTE?: InputMaybe<Scalars['Int']>
-  username_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
-  username_SHORTEST_GT?: InputMaybe<Scalars['Int']>
-  username_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
-  username_SHORTEST_LT?: InputMaybe<Scalars['Int']>
-  username_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
-}
-
-export type TypeBaseOwnerRelationship = OwnedBy & {
-  __typename?: 'TypeBaseOwnerRelationship'
-  cursor: Scalars['String']
-  data: Scalars['String']
-  node: User
-}
-
-export type TypeBaseOwnerUpdateConnectionInput = {
-  edge?: InputMaybe<OwnedByUpdateInput>
-  node?: InputMaybe<UserUpdateInput>
-}
-
-export type TypeBaseOwnerUpdateFieldInput = {
-  connect?: InputMaybe<TypeBaseOwnerConnectFieldInput>
-  connectOrCreate?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
-  create?: InputMaybe<TypeBaseOwnerCreateFieldInput>
-  delete?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
-  disconnect?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
-  update?: InputMaybe<TypeBaseOwnerUpdateConnectionInput>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
-}
-
-/** Fields to sort TypeBases by. The order in which sorts are applied is not guaranteed when specifying many fields in one TypeBaseSort object. */
-export type TypeBaseSort = {
-  id?: InputMaybe<SortDirection>
-  kind?: InputMaybe<SortDirection>
-  name?: InputMaybe<SortDirection>
-}
-
-export type TypeBaseUpdateInput = {
-  _on?: InputMaybe<TypeBaseImplementationsUpdateInput>
-  id?: InputMaybe<Scalars['ID']>
-  name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
-}
-
-export type TypeBaseWhere = {
-  _on?: InputMaybe<TypeBaseImplementationsWhere>
-  id?: InputMaybe<Scalars['ID']>
-  id_CONTAINS?: InputMaybe<Scalars['ID']>
-  id_ENDS_WITH?: InputMaybe<Scalars['ID']>
-  id_IN?: InputMaybe<Array<Scalars['ID']>>
-  id_NOT?: InputMaybe<Scalars['ID']>
-  id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
-  id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
-  id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
-  id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
-  id_STARTS_WITH?: InputMaybe<Scalars['ID']>
-  kind?: InputMaybe<TypeKind>
-  kind_IN?: InputMaybe<Array<TypeKind>>
-  kind_NOT?: InputMaybe<TypeKind>
-  kind_NOT_IN?: InputMaybe<Array<TypeKind>>
-  name?: InputMaybe<Scalars['String']>
-  name_CONTAINS?: InputMaybe<Scalars['String']>
-  name_ENDS_WITH?: InputMaybe<Scalars['String']>
-  name_IN?: InputMaybe<Array<Scalars['String']>>
-  name_NOT?: InputMaybe<Scalars['String']>
-  name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
-  name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
-  name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
-  name_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
-  name_STARTS_WITH?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<UserWhere>
-  ownerAggregate?: InputMaybe<TypeBaseOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  owner_NOT?: InputMaybe<UserWhere>
-}
-
 export enum TypeKind {
   ActionType = 'ActionType',
   AppType = 'AppType',
@@ -17804,7 +18051,7 @@ export type TypeReferencesConnection = {
 }
 
 /** Allows picking one of a set of types */
-export type UnionType = TypeBase &
+export type UnionType = IBaseType &
   WithDescendants & {
     __typename?: 'UnionType'
     descendantTypesIds: Array<Scalars['ID']>
@@ -17813,7 +18060,7 @@ export type UnionType = TypeBase &
     name: Scalars['String']
     owner: User
     ownerAggregate?: Maybe<UnionTypeUserOwnerAggregationSelection>
-    ownerConnection: TypeBaseOwnerConnection
+    ownerConnection: IBaseTypeOwnerConnection
     typesOfUnionType: Array<AnyType>
     typesOfUnionTypeConnection: UnionTypeTypesOfUnionTypeConnection
   }
@@ -17836,8 +18083,8 @@ export type UnionTypeOwnerConnectionArgs = {
   after?: InputMaybe<Scalars['String']>
   directed?: InputMaybe<Scalars['Boolean']>
   first?: InputMaybe<Scalars['Int']>
-  sort?: InputMaybe<Array<TypeBaseOwnerConnectionSort>>
-  where?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  sort?: InputMaybe<Array<IBaseTypeOwnerConnectionSort>>
+  where?: InputMaybe<IBaseTypeOwnerConnectionWhere>
 }
 
 /** Allows picking one of a set of types */
@@ -17863,12 +18110,12 @@ export type UnionTypeAggregateSelection = {
 }
 
 export type UnionTypeConnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeConnectInput>
 }
 
 export type UnionTypeConnectOrCreateInput = {
-  owner?: InputMaybe<TypeBaseOwnerConnectOrCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerConnectOrCreateFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeConnectOrCreateInput>
 }
 
@@ -17884,17 +18131,17 @@ export type UnionTypeCreateInput = {
   id: Scalars['ID']
   kind?: TypeKind
   name: Scalars['String']
-  owner?: InputMaybe<TypeBaseOwnerFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeCreateInput>
 }
 
 export type UnionTypeDeleteInput = {
-  owner?: InputMaybe<TypeBaseOwnerDeleteFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDeleteFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeDeleteInput>
 }
 
 export type UnionTypeDisconnectInput = {
-  owner?: InputMaybe<TypeBaseOwnerDisconnectFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerDisconnectFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeDisconnectInput>
 }
 
@@ -18020,7 +18267,7 @@ export type UnionTypeOwnerNodeAggregationWhereInput = {
 }
 
 export type UnionTypeRelationInput = {
-  owner?: InputMaybe<TypeBaseOwnerCreateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerCreateFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeCreateFieldInput>
 }
 
@@ -19237,7 +19484,7 @@ export type UnionTypeUniqueWhere = {
 export type UnionTypeUpdateInput = {
   id?: InputMaybe<Scalars['ID']>
   name?: InputMaybe<Scalars['String']>
-  owner?: InputMaybe<TypeBaseOwnerUpdateFieldInput>
+  owner?: InputMaybe<IBaseTypeOwnerUpdateFieldInput>
   typesOfUnionType?: InputMaybe<UnionTypeTypesOfUnionTypeUpdateInput>
 }
 
@@ -19290,8 +19537,8 @@ export type UnionTypeWhere = {
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
   owner?: InputMaybe<UserWhere>
   ownerAggregate?: InputMaybe<UnionTypeOwnerAggregateInput>
-  ownerConnection?: InputMaybe<TypeBaseOwnerConnectionWhere>
-  ownerConnection_NOT?: InputMaybe<TypeBaseOwnerConnectionWhere>
+  ownerConnection?: InputMaybe<IBaseTypeOwnerConnectionWhere>
+  ownerConnection_NOT?: InputMaybe<IBaseTypeOwnerConnectionWhere>
   owner_NOT?: InputMaybe<UserWhere>
   typesOfUnionTypeConnection_ALL?: InputMaybe<UnionTypeTypesOfUnionTypeConnectionWhere>
   typesOfUnionTypeConnection_NONE?: InputMaybe<UnionTypeTypesOfUnionTypeConnectionWhere>
@@ -19405,6 +19652,12 @@ export type UpdateEnumTypeValuesMutationResponse = {
 export type UpdateEnumTypesMutationResponse = {
   __typename?: 'UpdateEnumTypesMutationResponse'
   enumTypes: Array<EnumType>
+  info: UpdateInfo
+}
+
+export type UpdateGetBaseTypesReturnsMutationResponse = {
+  __typename?: 'UpdateGetBaseTypesReturnsMutationResponse'
+  getBaseTypesReturns: Array<GetBaseTypesReturn>
   info: UpdateInfo
 }
 
@@ -19543,7 +19796,8 @@ export type User = {
   tags: Array<Tag>
   tagsAggregate?: Maybe<UserTagTagsAggregationSelection>
   tagsConnection: UserTagsConnection
-  types: Array<TypeBase>
+  types: Array<BaseType>
+  typesAggregate?: Maybe<UserBaseTypeTypesAggregationSelection>
   typesConnection: UserTypesConnection
   username: Scalars['String']
 }
@@ -19626,8 +19880,13 @@ export type UserTagsConnectionArgs = {
 
 export type UserTypesArgs = {
   directed?: InputMaybe<Scalars['Boolean']>
-  options?: InputMaybe<TypeBaseOptions>
-  where?: InputMaybe<TypeBaseWhere>
+  options?: InputMaybe<BaseTypeOptions>
+  where?: InputMaybe<BaseTypeWhere>
+}
+
+export type UserTypesAggregateArgs = {
+  directed?: InputMaybe<Scalars['Boolean']>
+  where?: InputMaybe<BaseTypeWhere>
 }
 
 export type UserTypesConnectionArgs = {
@@ -19787,6 +20046,24 @@ export type UserAppsUpdateFieldInput = {
   disconnect?: InputMaybe<Array<UserAppsDisconnectFieldInput>>
   update?: InputMaybe<UserAppsUpdateConnectionInput>
   where?: InputMaybe<UserAppsConnectionWhere>
+}
+
+export type UserBaseTypeTypesAggregationSelection = {
+  __typename?: 'UserBaseTypeTypesAggregationSelection'
+  count: Scalars['Int']
+  edge?: Maybe<UserBaseTypeTypesEdgeAggregateSelection>
+  node?: Maybe<UserBaseTypeTypesNodeAggregateSelection>
+}
+
+export type UserBaseTypeTypesEdgeAggregateSelection = {
+  __typename?: 'UserBaseTypeTypesEdgeAggregateSelection'
+  data: StringAggregateSelectionNonNullable
+}
+
+export type UserBaseTypeTypesNodeAggregateSelection = {
+  __typename?: 'UserBaseTypeTypesNodeAggregateSelection'
+  id: IdAggregateSelectionNonNullable
+  name: StringAggregateSelectionNonNullable
 }
 
 export type UserComponentComponentsAggregationSelection = {
@@ -20370,10 +20647,32 @@ export type UserTagsUpdateFieldInput = {
   where?: InputMaybe<UserTagsConnectionWhere>
 }
 
+export type UserTypesAggregateInput = {
+  AND?: InputMaybe<Array<UserTypesAggregateInput>>
+  OR?: InputMaybe<Array<UserTypesAggregateInput>>
+  count?: InputMaybe<Scalars['Int']>
+  count_GT?: InputMaybe<Scalars['Int']>
+  count_GTE?: InputMaybe<Scalars['Int']>
+  count_LT?: InputMaybe<Scalars['Int']>
+  count_LTE?: InputMaybe<Scalars['Int']>
+  edge?: InputMaybe<UserTypesEdgeAggregationWhereInput>
+  node?: InputMaybe<UserTypesNodeAggregationWhereInput>
+}
+
 export type UserTypesConnectFieldInput = {
-  connect?: InputMaybe<TypeBaseConnectInput>
+  connect?: InputMaybe<Array<BaseTypeConnectInput>>
   edge: OwnedByCreateInput
-  where?: InputMaybe<TypeBaseConnectWhere>
+  where?: InputMaybe<BaseTypeConnectWhere>
+}
+
+export type UserTypesConnectOrCreateFieldInput = {
+  onCreate: UserTypesConnectOrCreateFieldInputOnCreate
+  where: BaseTypeConnectOrCreateWhere
+}
+
+export type UserTypesConnectOrCreateFieldInputOnCreate = {
+  edge: OwnedByCreateInput
+  node: BaseTypeOnCreateInput
 }
 
 export type UserTypesConnection = {
@@ -20385,7 +20684,7 @@ export type UserTypesConnection = {
 
 export type UserTypesConnectionSort = {
   edge?: InputMaybe<OwnedBySort>
-  node?: InputMaybe<TypeBaseSort>
+  node?: InputMaybe<BaseTypeSort>
 }
 
 export type UserTypesConnectionWhere = {
@@ -20393,44 +20692,97 @@ export type UserTypesConnectionWhere = {
   OR?: InputMaybe<Array<UserTypesConnectionWhere>>
   edge?: InputMaybe<OwnedByWhere>
   edge_NOT?: InputMaybe<OwnedByWhere>
-  node?: InputMaybe<TypeBaseWhere>
-  node_NOT?: InputMaybe<TypeBaseWhere>
+  node?: InputMaybe<BaseTypeWhere>
+  node_NOT?: InputMaybe<BaseTypeWhere>
 }
 
 export type UserTypesCreateFieldInput = {
   edge: OwnedByCreateInput
-  node: TypeBaseCreateInput
+  node: BaseTypeCreateInput
 }
 
 export type UserTypesDeleteFieldInput = {
-  delete?: InputMaybe<TypeBaseDeleteInput>
+  delete?: InputMaybe<BaseTypeDeleteInput>
   where?: InputMaybe<UserTypesConnectionWhere>
 }
 
 export type UserTypesDisconnectFieldInput = {
-  disconnect?: InputMaybe<TypeBaseDisconnectInput>
+  disconnect?: InputMaybe<BaseTypeDisconnectInput>
   where?: InputMaybe<UserTypesConnectionWhere>
+}
+
+export type UserTypesEdgeAggregationWhereInput = {
+  AND?: InputMaybe<Array<UserTypesEdgeAggregationWhereInput>>
+  OR?: InputMaybe<Array<UserTypesEdgeAggregationWhereInput>>
+  data_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  data_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  data_EQUAL?: InputMaybe<Scalars['String']>
+  data_GT?: InputMaybe<Scalars['Int']>
+  data_GTE?: InputMaybe<Scalars['Int']>
+  data_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  data_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  data_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  data_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  data_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  data_LT?: InputMaybe<Scalars['Int']>
+  data_LTE?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  data_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type UserTypesFieldInput = {
   connect?: InputMaybe<Array<UserTypesConnectFieldInput>>
+  connectOrCreate?: InputMaybe<Array<UserTypesConnectOrCreateFieldInput>>
   create?: InputMaybe<Array<UserTypesCreateFieldInput>>
+}
+
+export type UserTypesNodeAggregationWhereInput = {
+  AND?: InputMaybe<Array<UserTypesNodeAggregationWhereInput>>
+  OR?: InputMaybe<Array<UserTypesNodeAggregationWhereInput>>
+  id_EQUAL?: InputMaybe<Scalars['ID']>
+  name_AVERAGE_EQUAL?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_GTE?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LT?: InputMaybe<Scalars['Float']>
+  name_AVERAGE_LTE?: InputMaybe<Scalars['Float']>
+  name_EQUAL?: InputMaybe<Scalars['String']>
+  name_GT?: InputMaybe<Scalars['Int']>
+  name_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_GTE?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LT?: InputMaybe<Scalars['Int']>
+  name_LONGEST_LTE?: InputMaybe<Scalars['Int']>
+  name_LT?: InputMaybe<Scalars['Int']>
+  name_LTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_EQUAL?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_GTE?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LT?: InputMaybe<Scalars['Int']>
+  name_SHORTEST_LTE?: InputMaybe<Scalars['Int']>
 }
 
 export type UserTypesRelationship = OwnedBy & {
   __typename?: 'UserTypesRelationship'
   cursor: Scalars['String']
   data: Scalars['String']
-  node: TypeBase
+  node: BaseType
 }
 
 export type UserTypesUpdateConnectionInput = {
   edge?: InputMaybe<OwnedByUpdateInput>
-  node?: InputMaybe<TypeBaseUpdateInput>
+  node?: InputMaybe<BaseTypeUpdateInput>
 }
 
 export type UserTypesUpdateFieldInput = {
   connect?: InputMaybe<Array<UserTypesConnectFieldInput>>
+  connectOrCreate?: InputMaybe<Array<UserTypesConnectOrCreateFieldInput>>
   create?: InputMaybe<Array<UserTypesCreateFieldInput>>
   delete?: InputMaybe<Array<UserTypesDeleteFieldInput>>
   disconnect?: InputMaybe<Array<UserTypesDisconnectFieldInput>>
@@ -20545,10 +20897,19 @@ export type UserWhere = {
   tags_SINGLE?: InputMaybe<TagWhere>
   /** Return Users where some of the related Tags match this filter */
   tags_SOME?: InputMaybe<TagWhere>
+  typesAggregate?: InputMaybe<UserTypesAggregateInput>
   typesConnection_ALL?: InputMaybe<UserTypesConnectionWhere>
   typesConnection_NONE?: InputMaybe<UserTypesConnectionWhere>
   typesConnection_SINGLE?: InputMaybe<UserTypesConnectionWhere>
   typesConnection_SOME?: InputMaybe<UserTypesConnectionWhere>
+  /** Return Users where all of the related BaseTypes match this filter */
+  types_ALL?: InputMaybe<BaseTypeWhere>
+  /** Return Users where none of the related BaseTypes match this filter */
+  types_NONE?: InputMaybe<BaseTypeWhere>
+  /** Return Users where one of the related BaseTypes match this filter */
+  types_SINGLE?: InputMaybe<BaseTypeWhere>
+  /** Return Users where some of the related BaseTypes match this filter */
+  types_SOME?: InputMaybe<BaseTypeWhere>
   username?: InputMaybe<Scalars['String']>
   username_CONTAINS?: InputMaybe<Scalars['String']>
   username_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -21028,11 +21389,11 @@ export type TagPreviewFragment = {
 
 export type ActionTypeFragment = {
   __typename?: 'ActionType'
-} & TypeBase_ActionType_Fragment
+} & BaseType_ActionType_Fragment
 
 export type AppTypeFragment = {
   __typename?: 'AppType'
-} & TypeBase_AppType_Fragment
+} & BaseType_AppType_Fragment
 
 export type ArrayTypeFragment = {
   __typename?: 'ArrayType'
@@ -21050,17 +21411,145 @@ export type ArrayTypeFragment = {
     | { __typename?: 'ReactNodeType'; id: string; name: string }
     | { __typename?: 'RenderPropsType'; id: string; name: string }
     | { __typename?: 'UnionType'; id: string; name: string }
-} & TypeBase_ArrayType_Fragment
+} & BaseType_ArrayType_Fragment
+
+type BaseType_ActionType_Fragment = {
+  __typename: 'ActionType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_AppType_Fragment = {
+  __typename: 'AppType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_ArrayType_Fragment = {
+  __typename: 'ArrayType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_BaseType_Fragment = {
+  __typename: 'BaseType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_CodeMirrorType_Fragment = {
+  __typename: 'CodeMirrorType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_ElementType_Fragment = {
+  __typename: 'ElementType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_EnumType_Fragment = {
+  __typename: 'EnumType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_InterfaceType_Fragment = {
+  __typename: 'InterfaceType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_LambdaType_Fragment = {
+  __typename: 'LambdaType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_PageType_Fragment = {
+  __typename: 'PageType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_PrimitiveType_Fragment = {
+  __typename: 'PrimitiveType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_ReactNodeType_Fragment = {
+  __typename: 'ReactNodeType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_RenderPropsType_Fragment = {
+  __typename: 'RenderPropsType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+type BaseType_UnionType_Fragment = {
+  __typename: 'UnionType'
+  kind: TypeKind
+  id: string
+  name: string
+  owner: { __typename?: 'User'; id: string; auth0Id: string }
+}
+
+export type BaseTypeFragment =
+  | BaseType_ActionType_Fragment
+  | BaseType_AppType_Fragment
+  | BaseType_ArrayType_Fragment
+  | BaseType_BaseType_Fragment
+  | BaseType_CodeMirrorType_Fragment
+  | BaseType_ElementType_Fragment
+  | BaseType_EnumType_Fragment
+  | BaseType_InterfaceType_Fragment
+  | BaseType_LambdaType_Fragment
+  | BaseType_PageType_Fragment
+  | BaseType_PrimitiveType_Fragment
+  | BaseType_ReactNodeType_Fragment
+  | BaseType_RenderPropsType_Fragment
+  | BaseType_UnionType_Fragment
 
 export type CodeMirrorTypeFragment = {
   __typename?: 'CodeMirrorType'
   language: CodeMirrorLanguage
-} & TypeBase_CodeMirrorType_Fragment
+} & BaseType_CodeMirrorType_Fragment
 
 export type ElementTypeFragment = {
   __typename?: 'ElementType'
   elementKind: ElementTypeKind
-} & TypeBase_ElementType_Fragment
+} & BaseType_ElementType_Fragment
 
 export type EnumTypeValueFragment = {
   __typename?: 'EnumTypeValue'
@@ -21072,7 +21561,7 @@ export type EnumTypeValueFragment = {
 export type EnumTypeFragment = {
   __typename?: 'EnumType'
   allowedValues: Array<{ __typename?: 'EnumTypeValue' } & EnumTypeValueFragment>
-} & TypeBase_EnumType_Fragment
+} & BaseType_EnumType_Fragment
 
 export type FieldFragment = {
   __typename?: 'InterfaceTypeFieldsRelationship'
@@ -21081,27 +21570,14 @@ export type FieldFragment = {
   name?: string | null
   description?: string | null
   validationRules?: string | null
-  fieldType:
-    | { __typename?: 'ActionType'; id: string }
-    | { __typename?: 'AppType'; id: string }
-    | { __typename?: 'ArrayType'; id: string }
-    | { __typename?: 'CodeMirrorType'; id: string }
-    | { __typename?: 'ElementType'; id: string }
-    | { __typename?: 'EnumType'; id: string }
-    | { __typename?: 'InterfaceType'; id: string }
-    | { __typename?: 'LambdaType'; id: string }
-    | { __typename?: 'PageType'; id: string }
-    | { __typename?: 'PrimitiveType'; id: string }
-    | { __typename?: 'ReactNodeType'; id: string }
-    | { __typename?: 'RenderPropsType'; id: string }
-    | { __typename?: 'UnionType'; id: string }
+  fieldType: { __typename?: 'BaseType'; id: string }
 }
 
 export type InterfaceTypeFragment = {
   __typename?: 'InterfaceType'
   ownerConnection: {
-    __typename?: 'TypeBaseOwnerConnection'
-    edges: Array<{ __typename?: 'TypeBaseOwnerRelationship'; data: string }>
+    __typename?: 'IBaseTypeOwnerConnection'
+    edges: Array<{ __typename?: 'IBaseTypeOwnerRelationship'; data: string }>
   }
   fieldsConnection: {
     __typename?: 'InterfaceTypeFieldsConnection'
@@ -21109,216 +21585,102 @@ export type InterfaceTypeFragment = {
       { __typename?: 'InterfaceTypeFieldsRelationship' } & FieldFragment
     >
   }
-} & TypeBase_InterfaceType_Fragment
+} & BaseType_InterfaceType_Fragment
 
 export type LambdaTypeFragment = {
   __typename?: 'LambdaType'
-} & TypeBase_LambdaType_Fragment
+} & BaseType_LambdaType_Fragment
 
 export type PageTypeFragment = {
   __typename?: 'PageType'
-} & TypeBase_PageType_Fragment
+} & BaseType_PageType_Fragment
 
 export type PrimitiveTypeFragment = {
   __typename?: 'PrimitiveType'
   primitiveKind: PrimitiveTypeKind
-} & TypeBase_PrimitiveType_Fragment
+} & BaseType_PrimitiveType_Fragment
 
 export type ReactNodeTypeFragment = {
   __typename?: 'ReactNodeType'
-} & TypeBase_ReactNodeType_Fragment
+} & BaseType_ReactNodeType_Fragment
 
 export type RenderPropsTypeFragment = {
   __typename?: 'RenderPropsType'
-} & TypeBase_RenderPropsType_Fragment
-
-type TypeBase_ActionType_Fragment = {
-  __typename: 'ActionType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_AppType_Fragment = {
-  __typename: 'AppType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_ArrayType_Fragment = {
-  __typename: 'ArrayType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_CodeMirrorType_Fragment = {
-  __typename: 'CodeMirrorType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_ElementType_Fragment = {
-  __typename: 'ElementType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_EnumType_Fragment = {
-  __typename: 'EnumType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_InterfaceType_Fragment = {
-  __typename: 'InterfaceType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_LambdaType_Fragment = {
-  __typename: 'LambdaType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_PageType_Fragment = {
-  __typename: 'PageType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_PrimitiveType_Fragment = {
-  __typename: 'PrimitiveType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_ReactNodeType_Fragment = {
-  __typename: 'ReactNodeType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_RenderPropsType_Fragment = {
-  __typename: 'RenderPropsType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-type TypeBase_UnionType_Fragment = {
-  __typename: 'UnionType'
-  kind: TypeKind
-  id: string
-  name: string
-  owner: { __typename?: 'User'; id: string; auth0Id: string }
-}
-
-export type TypeBaseFragment =
-  | TypeBase_ActionType_Fragment
-  | TypeBase_AppType_Fragment
-  | TypeBase_ArrayType_Fragment
-  | TypeBase_CodeMirrorType_Fragment
-  | TypeBase_ElementType_Fragment
-  | TypeBase_EnumType_Fragment
-  | TypeBase_InterfaceType_Fragment
-  | TypeBase_LambdaType_Fragment
-  | TypeBase_PageType_Fragment
-  | TypeBase_PrimitiveType_Fragment
-  | TypeBase_ReactNodeType_Fragment
-  | TypeBase_RenderPropsType_Fragment
-  | TypeBase_UnionType_Fragment
+} & BaseType_RenderPropsType_Fragment
 
 type Type_ActionType_Fragment = {
   __typename?: 'ActionType'
-} & TypeBase_ActionType_Fragment &
+} & BaseType_ActionType_Fragment &
   ActionTypeFragment
 
 type Type_AppType_Fragment = {
   __typename?: 'AppType'
-} & TypeBase_AppType_Fragment &
+} & BaseType_AppType_Fragment &
   AppTypeFragment
 
 type Type_ArrayType_Fragment = {
   __typename?: 'ArrayType'
-} & TypeBase_ArrayType_Fragment &
+} & BaseType_ArrayType_Fragment &
   ArrayTypeFragment
+
+type Type_BaseType_Fragment = {
+  __typename?: 'BaseType'
+} & BaseType_BaseType_Fragment
 
 type Type_CodeMirrorType_Fragment = {
   __typename?: 'CodeMirrorType'
-} & TypeBase_CodeMirrorType_Fragment &
+} & BaseType_CodeMirrorType_Fragment &
   CodeMirrorTypeFragment
 
 type Type_ElementType_Fragment = {
   __typename?: 'ElementType'
-} & TypeBase_ElementType_Fragment &
+} & BaseType_ElementType_Fragment &
   ElementTypeFragment
 
 type Type_EnumType_Fragment = {
   __typename?: 'EnumType'
-} & TypeBase_EnumType_Fragment &
+} & BaseType_EnumType_Fragment &
   EnumTypeFragment
 
 type Type_InterfaceType_Fragment = {
   __typename?: 'InterfaceType'
-} & TypeBase_InterfaceType_Fragment &
+} & BaseType_InterfaceType_Fragment &
   InterfaceTypeFragment
 
 type Type_LambdaType_Fragment = {
   __typename?: 'LambdaType'
-} & TypeBase_LambdaType_Fragment &
+} & BaseType_LambdaType_Fragment &
   LambdaTypeFragment
 
 type Type_PageType_Fragment = {
   __typename?: 'PageType'
-} & TypeBase_PageType_Fragment &
+} & BaseType_PageType_Fragment &
   PageTypeFragment
 
 type Type_PrimitiveType_Fragment = {
   __typename?: 'PrimitiveType'
-} & TypeBase_PrimitiveType_Fragment &
+} & BaseType_PrimitiveType_Fragment &
   PrimitiveTypeFragment
 
 type Type_ReactNodeType_Fragment = {
   __typename?: 'ReactNodeType'
-} & TypeBase_ReactNodeType_Fragment
+} & BaseType_ReactNodeType_Fragment
 
 type Type_RenderPropsType_Fragment = {
   __typename?: 'RenderPropsType'
-} & TypeBase_RenderPropsType_Fragment &
+} & BaseType_RenderPropsType_Fragment &
   RenderPropsTypeFragment
 
 type Type_UnionType_Fragment = {
   __typename?: 'UnionType'
-} & TypeBase_UnionType_Fragment &
+} & BaseType_UnionType_Fragment &
   UnionTypeFragment
 
 export type TypeFragment =
   | Type_ActionType_Fragment
   | Type_AppType_Fragment
   | Type_ArrayType_Fragment
+  | Type_BaseType_Fragment
   | Type_CodeMirrorType_Fragment
   | Type_ElementType_Fragment
   | Type_EnumType_Fragment
@@ -21347,7 +21709,7 @@ export type UnionTypeFragment = {
     | { __typename?: 'RenderPropsType'; id: string; name: string }
     | { __typename?: 'UnionType'; id: string; name: string }
   >
-} & TypeBase_UnionType_Fragment
+} & BaseType_UnionType_Fragment
 
 export type UserFragment = {
   __typename?: 'User'

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -91,7 +91,7 @@ enum ActionKind {
 """
 Allows picking a action from the list of actions
 """
-type ActionType implements TypeBase {
+type ActionType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -104,9 +104,9 @@ type ActionType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type ActionTypeAggregateSelection {
@@ -116,11 +116,11 @@ type ActionTypeAggregateSelection {
 }
 
 input ActionTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input ActionTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input ActionTypeConnectOrCreateWhere {
@@ -135,15 +135,15 @@ input ActionTypeCreateInput {
   id: ID!
   kind: TypeKind! = ActionType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input ActionTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input ActionTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type ActionTypeEdge {
@@ -270,7 +270,7 @@ input ActionTypeOwnerNodeAggregationWhereInput {
 }
 
 input ActionTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -289,7 +289,7 @@ input ActionTypeUniqueWhere {
 input ActionTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type ActionTypeUserOwnerAggregationSelection {
@@ -338,8 +338,8 @@ input ActionTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: ActionTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -1841,7 +1841,7 @@ input AppStoreUpdateFieldInput {
 """
 Allows picking a app from the list of apps
 """
-type AppType implements TypeBase {
+type AppType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -1854,9 +1854,9 @@ type AppType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type AppTypeAggregateSelection {
@@ -1866,11 +1866,11 @@ type AppTypeAggregateSelection {
 }
 
 input AppTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input AppTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input AppTypeConnectOrCreateWhere {
@@ -1885,15 +1885,15 @@ input AppTypeCreateInput {
   id: ID!
   kind: TypeKind! = AppType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input AppTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input AppTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type AppTypeEdge {
@@ -2020,7 +2020,7 @@ input AppTypeOwnerNodeAggregationWhereInput {
 }
 
 input AppTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -2039,7 +2039,7 @@ input AppTypeUniqueWhere {
 input AppTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type AppTypeUserOwnerAggregationSelection {
@@ -2088,8 +2088,8 @@ input AppTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: AppTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -2230,7 +2230,7 @@ type AppsConnection {
 ArrayType Allows defining a variable number of items of a given type.
 Contains a reference to another type which is the array item type.
 """
-type ArrayType implements TypeBase & WithDescendants {
+type ArrayType implements IBaseType & WithDescendants {
   descendantTypesIds: [ID!]!
   id: ID!
   itemType(
@@ -2255,9 +2255,9 @@ type ArrayType implements TypeBase & WithDescendants {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type ArrayTypeAggregateSelection {
@@ -2268,12 +2268,12 @@ type ArrayTypeAggregateSelection {
 
 input ArrayTypeConnectInput {
   itemType: ArrayTypeItemTypeConnectInput
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input ArrayTypeConnectOrCreateInput {
   itemType: ArrayTypeItemTypeConnectOrCreateInput
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input ArrayTypeConnectOrCreateWhere {
@@ -2289,17 +2289,17 @@ input ArrayTypeCreateInput {
   itemType: ArrayTypeItemTypeCreateInput
   kind: TypeKind! = ArrayType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input ArrayTypeDeleteInput {
   itemType: ArrayTypeItemTypeDeleteInput
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input ArrayTypeDisconnectInput {
   itemType: ArrayTypeItemTypeDisconnectInput
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type ArrayTypeEdge {
@@ -3281,7 +3281,7 @@ input ArrayTypeOwnerNodeAggregationWhereInput {
 
 input ArrayTypeRelationInput {
   itemType: ArrayTypeItemTypeCreateFieldInput
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -3301,7 +3301,7 @@ input ArrayTypeUpdateInput {
   id: ID
   itemType: ArrayTypeItemTypeUpdateInput
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type ArrayTypeUserOwnerAggregationSelection {
@@ -3352,8 +3352,8 @@ input ArrayTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: ArrayTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -4364,6 +4364,240 @@ type AtomsConnection {
   totalCount: Int!
 }
 
+type BaseType implements IBaseType {
+  id: ID!
+  kind: TypeKind!
+  name: String!
+  owner(directed: Boolean = true, options: UserOptions, where: UserWhere): User!
+  ownerAggregate(
+    directed: Boolean = true
+    where: UserWhere
+  ): BaseTypeUserOwnerAggregationSelection
+  ownerConnection(
+    after: String
+    directed: Boolean = true
+    first: Int
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
+}
+
+input BaseTypeConnectInput {
+  owner: IBaseTypeOwnerConnectFieldInput
+}
+
+input BaseTypeConnectOrCreateWhere {
+  node: BaseTypeUniqueWhere!
+}
+
+input BaseTypeConnectWhere {
+  node: BaseTypeWhere!
+}
+
+input BaseTypeCreateInput {
+  id: ID!
+  kind: TypeKind!
+  name: String!
+  owner: IBaseTypeOwnerFieldInput
+}
+
+input BaseTypeDeleteInput {
+  owner: IBaseTypeOwnerDeleteFieldInput
+}
+
+input BaseTypeDisconnectInput {
+  owner: IBaseTypeOwnerDisconnectFieldInput
+}
+
+input BaseTypeOnCreateInput {
+  id: ID!
+  name: String!
+}
+
+input BaseTypeOptions {
+  limit: Int
+  offset: Int
+
+  """
+  Specify one or more BaseTypeSort objects to sort BaseTypes by. The sorts will be applied in the order in which they are arranged in the array.
+  """
+  sort: [BaseTypeSort!]
+}
+
+input BaseTypeOwnerAggregateInput {
+  AND: [BaseTypeOwnerAggregateInput!]
+  OR: [BaseTypeOwnerAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  edge: BaseTypeOwnerEdgeAggregationWhereInput
+  node: BaseTypeOwnerNodeAggregationWhereInput
+}
+
+input BaseTypeOwnerEdgeAggregationWhereInput {
+  AND: [BaseTypeOwnerEdgeAggregationWhereInput!]
+  OR: [BaseTypeOwnerEdgeAggregationWhereInput!]
+  data_AVERAGE_EQUAL: Float
+  data_AVERAGE_GT: Float
+  data_AVERAGE_GTE: Float
+  data_AVERAGE_LT: Float
+  data_AVERAGE_LTE: Float
+  data_EQUAL: String
+  data_GT: Int
+  data_GTE: Int
+  data_LONGEST_EQUAL: Int
+  data_LONGEST_GT: Int
+  data_LONGEST_GTE: Int
+  data_LONGEST_LT: Int
+  data_LONGEST_LTE: Int
+  data_LT: Int
+  data_LTE: Int
+  data_SHORTEST_EQUAL: Int
+  data_SHORTEST_GT: Int
+  data_SHORTEST_GTE: Int
+  data_SHORTEST_LT: Int
+  data_SHORTEST_LTE: Int
+}
+
+input BaseTypeOwnerNodeAggregationWhereInput {
+  AND: [BaseTypeOwnerNodeAggregationWhereInput!]
+  OR: [BaseTypeOwnerNodeAggregationWhereInput!]
+  auth0Id_AVERAGE_EQUAL: Float
+  auth0Id_AVERAGE_GT: Float
+  auth0Id_AVERAGE_GTE: Float
+  auth0Id_AVERAGE_LT: Float
+  auth0Id_AVERAGE_LTE: Float
+  auth0Id_EQUAL: String
+  auth0Id_GT: Int
+  auth0Id_GTE: Int
+  auth0Id_LONGEST_EQUAL: Int
+  auth0Id_LONGEST_GT: Int
+  auth0Id_LONGEST_GTE: Int
+  auth0Id_LONGEST_LT: Int
+  auth0Id_LONGEST_LTE: Int
+  auth0Id_LT: Int
+  auth0Id_LTE: Int
+  auth0Id_SHORTEST_EQUAL: Int
+  auth0Id_SHORTEST_GT: Int
+  auth0Id_SHORTEST_GTE: Int
+  auth0Id_SHORTEST_LT: Int
+  auth0Id_SHORTEST_LTE: Int
+  email_AVERAGE_EQUAL: Float
+  email_AVERAGE_GT: Float
+  email_AVERAGE_GTE: Float
+  email_AVERAGE_LT: Float
+  email_AVERAGE_LTE: Float
+  email_EQUAL: String
+  email_GT: Int
+  email_GTE: Int
+  email_LONGEST_EQUAL: Int
+  email_LONGEST_GT: Int
+  email_LONGEST_GTE: Int
+  email_LONGEST_LT: Int
+  email_LONGEST_LTE: Int
+  email_LT: Int
+  email_LTE: Int
+  email_SHORTEST_EQUAL: Int
+  email_SHORTEST_GT: Int
+  email_SHORTEST_GTE: Int
+  email_SHORTEST_LT: Int
+  email_SHORTEST_LTE: Int
+  id_EQUAL: ID
+  username_AVERAGE_EQUAL: Float
+  username_AVERAGE_GT: Float
+  username_AVERAGE_GTE: Float
+  username_AVERAGE_LT: Float
+  username_AVERAGE_LTE: Float
+  username_EQUAL: String
+  username_GT: Int
+  username_GTE: Int
+  username_LONGEST_EQUAL: Int
+  username_LONGEST_GT: Int
+  username_LONGEST_GTE: Int
+  username_LONGEST_LT: Int
+  username_LONGEST_LTE: Int
+  username_LT: Int
+  username_LTE: Int
+  username_SHORTEST_EQUAL: Int
+  username_SHORTEST_GT: Int
+  username_SHORTEST_GTE: Int
+  username_SHORTEST_LT: Int
+  username_SHORTEST_LTE: Int
+}
+
+"""
+Fields to sort BaseTypes by. The order in which sorts are applied is not guaranteed when specifying many fields in one BaseTypeSort object.
+"""
+input BaseTypeSort {
+  id: SortDirection
+  kind: SortDirection
+  name: SortDirection
+}
+
+input BaseTypeUniqueWhere {
+  id: ID
+  name: String
+}
+
+input BaseTypeUpdateInput {
+  id: ID
+  name: String
+  owner: IBaseTypeOwnerUpdateFieldInput
+}
+
+type BaseTypeUserOwnerAggregationSelection {
+  count: Int!
+  edge: BaseTypeUserOwnerEdgeAggregateSelection
+  node: BaseTypeUserOwnerNodeAggregateSelection
+}
+
+type BaseTypeUserOwnerEdgeAggregateSelection {
+  data: StringAggregateSelectionNonNullable!
+}
+
+type BaseTypeUserOwnerNodeAggregateSelection {
+  auth0Id: StringAggregateSelectionNonNullable!
+  email: StringAggregateSelectionNonNullable!
+  id: IDAggregateSelectionNonNullable!
+  username: StringAggregateSelectionNonNullable!
+}
+
+input BaseTypeWhere {
+  AND: [BaseTypeWhere!]
+  OR: [BaseTypeWhere!]
+  id: ID
+  id_CONTAINS: ID
+  id_ENDS_WITH: ID
+  id_IN: [ID!]
+  id_NOT: ID
+  id_NOT_CONTAINS: ID
+  id_NOT_ENDS_WITH: ID
+  id_NOT_IN: [ID!]
+  id_NOT_STARTS_WITH: ID
+  id_STARTS_WITH: ID
+  kind: TypeKind
+  kind_IN: [TypeKind!]
+  kind_NOT: TypeKind
+  kind_NOT_IN: [TypeKind!]
+  name: String
+  name_CONTAINS: String
+  name_ENDS_WITH: String
+  name_IN: [String!]
+  name_NOT: String
+  name_NOT_CONTAINS: String
+  name_NOT_ENDS_WITH: String
+  name_NOT_IN: [String!]
+  name_NOT_STARTS_WITH: String
+  name_STARTS_WITH: String
+  owner: UserWhere
+  ownerAggregate: BaseTypeOwnerAggregateInput
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
+  owner_NOT: UserWhere
+}
+
 type CodeAction implements ActionBase {
   """
   Code to run when action is triggered
@@ -4584,7 +4818,7 @@ enum CodeMirrorLanguage {
 """
 Allows editing the value using a code mirror editor
 """
-type CodeMirrorType implements TypeBase {
+type CodeMirrorType implements IBaseType {
   id: ID!
   kind: TypeKind!
   language: CodeMirrorLanguage!
@@ -4598,9 +4832,9 @@ type CodeMirrorType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type CodeMirrorTypeAggregateSelection {
@@ -4610,11 +4844,11 @@ type CodeMirrorTypeAggregateSelection {
 }
 
 input CodeMirrorTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input CodeMirrorTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input CodeMirrorTypeConnectOrCreateWhere {
@@ -4630,15 +4864,15 @@ input CodeMirrorTypeCreateInput {
   kind: TypeKind! = CodeMirrorType
   language: CodeMirrorLanguage!
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input CodeMirrorTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input CodeMirrorTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type CodeMirrorTypeEdge {
@@ -4765,7 +4999,7 @@ input CodeMirrorTypeOwnerNodeAggregationWhereInput {
 }
 
 input CodeMirrorTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -4786,7 +5020,7 @@ input CodeMirrorTypeUpdateInput {
   id: ID
   language: CodeMirrorLanguage
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type CodeMirrorTypeUserOwnerAggregationSelection {
@@ -4839,8 +5073,8 @@ input CodeMirrorTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: CodeMirrorTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -5590,6 +5824,11 @@ type CreateEnumTypeValuesMutationResponse {
 
 type CreateEnumTypesMutationResponse {
   enumTypes: [EnumType!]!
+  info: CreateInfo!
+}
+
+type CreateGetBaseTypesReturnsMutationResponse {
+  getBaseTypesReturns: [GetBaseTypesReturn!]!
   info: CreateInfo!
 }
 
@@ -8400,7 +8639,7 @@ Comparison between different element types:
 - ReactNodeType: Component select box, results it 'ReactNode' value
 - ElementType: Current tree element select box, results it 'ReactNode' value
 """
-type ElementType implements TypeBase {
+type ElementType implements IBaseType {
   """
   Allows scoping the type of element to only descendants, children or all elements
   """
@@ -8417,9 +8656,9 @@ type ElementType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type ElementTypeAggregateSelection {
@@ -8429,11 +8668,11 @@ type ElementTypeAggregateSelection {
 }
 
 input ElementTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input ElementTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input ElementTypeConnectOrCreateWhere {
@@ -8449,15 +8688,15 @@ input ElementTypeCreateInput {
   id: ID!
   kind: TypeKind! = ElementType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input ElementTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input ElementTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type ElementTypeEdge {
@@ -8591,7 +8830,7 @@ input ElementTypeOwnerNodeAggregationWhereInput {
 }
 
 input ElementTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -8612,7 +8851,7 @@ input ElementTypeUpdateInput {
   elementKind: ElementTypeKind
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type ElementTypeUserOwnerAggregationSelection {
@@ -8665,8 +8904,8 @@ input ElementTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: ElementTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -8904,7 +9143,7 @@ Allows choosing one of a set of allowed values.
 The value gets passed to the render pipe as a Enum Type Value id.
 The actual value must be de-referenced by the id.
 """
-type EnumType implements TypeBase {
+type EnumType implements IBaseType {
   allowedValues(
     directed: Boolean = true
     options: EnumTypeValueOptions
@@ -8933,9 +9172,9 @@ type EnumType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type EnumTypeAggregateSelection {
@@ -9062,11 +9301,11 @@ input EnumTypeAllowedValuesUpdateFieldInput {
 
 input EnumTypeConnectInput {
   allowedValues: [EnumTypeAllowedValuesConnectFieldInput!]
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input EnumTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input EnumTypeConnectOrCreateWhere {
@@ -9082,17 +9321,17 @@ input EnumTypeCreateInput {
   id: ID!
   kind: TypeKind! = EnumType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input EnumTypeDeleteInput {
   allowedValues: [EnumTypeAllowedValuesDeleteFieldInput!]
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input EnumTypeDisconnectInput {
   allowedValues: [EnumTypeAllowedValuesDisconnectFieldInput!]
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type EnumTypeEdge {
@@ -9231,7 +9470,7 @@ input EnumTypeOwnerNodeAggregationWhereInput {
 
 input EnumTypeRelationInput {
   allowedValues: [EnumTypeAllowedValuesCreateFieldInput!]
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -9251,7 +9490,7 @@ input EnumTypeUpdateInput {
   allowedValues: [EnumTypeAllowedValuesUpdateFieldInput!]
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type EnumTypeUserOwnerAggregationSelection {
@@ -9579,8 +9818,8 @@ input EnumTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: EnumTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -9675,6 +9914,72 @@ input FieldWhere {
   validationRules_NOT_IN: [String]
   validationRules_NOT_STARTS_WITH: String
   validationRules_STARTS_WITH: String
+}
+
+input GetBaseTypesOptions {
+  limit: Int
+  offset: Int
+}
+
+type GetBaseTypesReturn {
+  items: [BaseType!]!
+  totalCount: Int!
+}
+
+type GetBaseTypesReturnAggregateSelection {
+  count: Int!
+  totalCount: IntAggregateSelectionNonNullable!
+}
+
+input GetBaseTypesReturnCreateInput {
+  totalCount: Int!
+}
+
+type GetBaseTypesReturnEdge {
+  cursor: String!
+  node: GetBaseTypesReturn!
+}
+
+input GetBaseTypesReturnOptions {
+  limit: Int
+  offset: Int
+
+  """
+  Specify one or more GetBaseTypesReturnSort objects to sort GetBaseTypesReturns by. The sorts will be applied in the order in which they are arranged in the array.
+  """
+  sort: [GetBaseTypesReturnSort!]
+}
+
+"""
+Fields to sort GetBaseTypesReturns by. The order in which sorts are applied is not guaranteed when specifying many fields in one GetBaseTypesReturnSort object.
+"""
+input GetBaseTypesReturnSort {
+  totalCount: SortDirection
+}
+
+input GetBaseTypesReturnUpdateInput {
+  totalCount: Int
+  totalCount_DECREMENT: Int
+  totalCount_INCREMENT: Int
+}
+
+input GetBaseTypesReturnWhere {
+  AND: [GetBaseTypesReturnWhere!]
+  OR: [GetBaseTypesReturnWhere!]
+  totalCount: Int
+  totalCount_GT: Int
+  totalCount_GTE: Int
+  totalCount_IN: [Int!]
+  totalCount_LT: Int
+  totalCount_LTE: Int
+  totalCount_NOT: Int
+  totalCount_NOT_IN: [Int!]
+}
+
+type GetBaseTypesReturnsConnection {
+  edges: [GetBaseTypesReturnEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type Hook {
@@ -10211,6 +10516,92 @@ type HooksConnection {
   totalCount: Int!
 }
 
+interface IBaseType {
+  id: ID!
+  kind: TypeKind!
+  name: String!
+  owner: User!
+  ownerConnection: IBaseTypeOwnerConnection!
+}
+
+input IBaseTypeOwnerConnectFieldInput {
+  connect: UserConnectInput
+  edge: OwnedByCreateInput!
+  where: UserConnectWhere
+}
+
+input IBaseTypeOwnerConnectOrCreateFieldInput {
+  onCreate: IBaseTypeOwnerConnectOrCreateFieldInputOnCreate!
+  where: UserConnectOrCreateWhere!
+}
+
+input IBaseTypeOwnerConnectOrCreateFieldInputOnCreate {
+  edge: OwnedByCreateInput!
+  node: UserOnCreateInput!
+}
+
+type IBaseTypeOwnerConnection {
+  edges: [IBaseTypeOwnerRelationship!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input IBaseTypeOwnerConnectionSort {
+  edge: OwnedBySort
+  node: UserSort
+}
+
+input IBaseTypeOwnerConnectionWhere {
+  AND: [IBaseTypeOwnerConnectionWhere!]
+  OR: [IBaseTypeOwnerConnectionWhere!]
+  edge: OwnedByWhere
+  edge_NOT: OwnedByWhere
+  node: UserWhere
+  node_NOT: UserWhere
+}
+
+input IBaseTypeOwnerCreateFieldInput {
+  edge: OwnedByCreateInput!
+  node: UserCreateInput!
+}
+
+input IBaseTypeOwnerDeleteFieldInput {
+  delete: UserDeleteInput
+  where: IBaseTypeOwnerConnectionWhere
+}
+
+input IBaseTypeOwnerDisconnectFieldInput {
+  disconnect: UserDisconnectInput
+  where: IBaseTypeOwnerConnectionWhere
+}
+
+input IBaseTypeOwnerFieldInput {
+  connect: IBaseTypeOwnerConnectFieldInput
+  connectOrCreate: IBaseTypeOwnerConnectOrCreateFieldInput
+  create: IBaseTypeOwnerCreateFieldInput
+}
+
+type IBaseTypeOwnerRelationship implements OwnedBy {
+  cursor: String!
+  data: String!
+  node: User!
+}
+
+input IBaseTypeOwnerUpdateConnectionInput {
+  edge: OwnedByUpdateInput
+  node: UserUpdateInput
+}
+
+input IBaseTypeOwnerUpdateFieldInput {
+  connect: IBaseTypeOwnerConnectFieldInput
+  connectOrCreate: IBaseTypeOwnerConnectOrCreateFieldInput
+  create: IBaseTypeOwnerCreateFieldInput
+  delete: IBaseTypeOwnerDeleteFieldInput
+  disconnect: IBaseTypeOwnerDisconnectFieldInput
+  update: IBaseTypeOwnerUpdateConnectionInput
+  where: IBaseTypeOwnerConnectionWhere
+}
+
 type IDAggregateSelectionNonNullable {
   longest: ID!
   shortest: ID!
@@ -10226,7 +10617,7 @@ type IntAggregateSelectionNonNullable {
 """
 Represents an object type with multiple fields
 """
-type InterfaceType implements TypeBase & WithDescendants {
+type InterfaceType implements IBaseType & WithDescendants {
   apiOfAtoms(
     directed: Boolean = true
     options: AtomOptions
@@ -10244,12 +10635,16 @@ type InterfaceType implements TypeBase & WithDescendants {
     where: InterfaceTypeApiOfAtomsConnectionWhere
   ): InterfaceTypeApiOfAtomsConnection!
   descendantTypesIds: [ID!]!
-  fieldFor: [TypeBase!]!
+  fieldFor: [BaseType!]!
   fields(
     directed: Boolean = true
-    options: TypeBaseOptions
-    where: TypeBaseWhere
-  ): [TypeBase!]!
+    options: BaseTypeOptions
+    where: BaseTypeWhere
+  ): [BaseType!]!
+  fieldsAggregate(
+    directed: Boolean = true
+    where: BaseTypeWhere
+  ): InterfaceTypeBaseTypeFieldsAggregationSelection
   fieldsConnection(
     after: String
     directed: Boolean = true
@@ -10269,9 +10664,9 @@ type InterfaceType implements TypeBase & WithDescendants {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type InterfaceTypeAggregateSelection {
@@ -10418,15 +10813,35 @@ type InterfaceTypeAtomApiOfAtomsNodeAggregateSelection {
   name: StringAggregateSelectionNonNullable!
 }
 
+type InterfaceTypeBaseTypeFieldsAggregationSelection {
+  count: Int!
+  edge: InterfaceTypeBaseTypeFieldsEdgeAggregateSelection
+  node: InterfaceTypeBaseTypeFieldsNodeAggregateSelection
+}
+
+type InterfaceTypeBaseTypeFieldsEdgeAggregateSelection {
+  description: StringAggregateSelectionNullable!
+  id: IDAggregateSelectionNonNullable!
+  key: StringAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNullable!
+  validationRules: StringAggregateSelectionNullable!
+}
+
+type InterfaceTypeBaseTypeFieldsNodeAggregateSelection {
+  id: IDAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNonNullable!
+}
+
 input InterfaceTypeConnectInput {
   apiOfAtoms: [InterfaceTypeApiOfAtomsConnectFieldInput!]
   fields: [InterfaceTypeFieldsConnectFieldInput!]
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input InterfaceTypeConnectOrCreateInput {
   apiOfAtoms: [InterfaceTypeApiOfAtomsConnectOrCreateFieldInput!]
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  fields: [InterfaceTypeFieldsConnectOrCreateFieldInput!]
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input InterfaceTypeConnectOrCreateWhere {
@@ -10443,19 +10858,19 @@ input InterfaceTypeCreateInput {
   id: ID!
   kind: TypeKind! = InterfaceType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input InterfaceTypeDeleteInput {
   apiOfAtoms: [InterfaceTypeApiOfAtomsDeleteFieldInput!]
   fields: [InterfaceTypeFieldsDeleteFieldInput!]
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input InterfaceTypeDisconnectInput {
   apiOfAtoms: [InterfaceTypeApiOfAtomsDisconnectFieldInput!]
   fields: [InterfaceTypeFieldsDisconnectFieldInput!]
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type InterfaceTypeEdge {
@@ -10463,10 +10878,32 @@ type InterfaceTypeEdge {
   node: InterfaceType!
 }
 
+input InterfaceTypeFieldsAggregateInput {
+  AND: [InterfaceTypeFieldsAggregateInput!]
+  OR: [InterfaceTypeFieldsAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  edge: InterfaceTypeFieldsEdgeAggregationWhereInput
+  node: InterfaceTypeFieldsNodeAggregationWhereInput
+}
+
 input InterfaceTypeFieldsConnectFieldInput {
-  connect: TypeBaseConnectInput
+  connect: [BaseTypeConnectInput!]
   edge: FieldCreateInput!
-  where: TypeBaseConnectWhere
+  where: BaseTypeConnectWhere
+}
+
+input InterfaceTypeFieldsConnectOrCreateFieldInput {
+  onCreate: InterfaceTypeFieldsConnectOrCreateFieldInputOnCreate!
+  where: BaseTypeConnectOrCreateWhere!
+}
+
+input InterfaceTypeFieldsConnectOrCreateFieldInputOnCreate {
+  edge: FieldCreateInput!
+  node: BaseTypeOnCreateInput!
 }
 
 type InterfaceTypeFieldsConnection {
@@ -10477,7 +10914,7 @@ type InterfaceTypeFieldsConnection {
 
 input InterfaceTypeFieldsConnectionSort {
   edge: FieldSort
-  node: TypeBaseSort
+  node: BaseTypeSort
 }
 
 input InterfaceTypeFieldsConnectionWhere {
@@ -10485,28 +10922,141 @@ input InterfaceTypeFieldsConnectionWhere {
   OR: [InterfaceTypeFieldsConnectionWhere!]
   edge: FieldWhere
   edge_NOT: FieldWhere
-  node: TypeBaseWhere
-  node_NOT: TypeBaseWhere
+  node: BaseTypeWhere
+  node_NOT: BaseTypeWhere
 }
 
 input InterfaceTypeFieldsCreateFieldInput {
   edge: FieldCreateInput!
-  node: TypeBaseCreateInput!
+  node: BaseTypeCreateInput!
 }
 
 input InterfaceTypeFieldsDeleteFieldInput {
-  delete: TypeBaseDeleteInput
+  delete: BaseTypeDeleteInput
   where: InterfaceTypeFieldsConnectionWhere
 }
 
 input InterfaceTypeFieldsDisconnectFieldInput {
-  disconnect: TypeBaseDisconnectInput
+  disconnect: BaseTypeDisconnectInput
   where: InterfaceTypeFieldsConnectionWhere
+}
+
+input InterfaceTypeFieldsEdgeAggregationWhereInput {
+  AND: [InterfaceTypeFieldsEdgeAggregationWhereInput!]
+  OR: [InterfaceTypeFieldsEdgeAggregationWhereInput!]
+  description_AVERAGE_EQUAL: Float
+  description_AVERAGE_GT: Float
+  description_AVERAGE_GTE: Float
+  description_AVERAGE_LT: Float
+  description_AVERAGE_LTE: Float
+  description_EQUAL: String
+  description_GT: Int
+  description_GTE: Int
+  description_LONGEST_EQUAL: Int
+  description_LONGEST_GT: Int
+  description_LONGEST_GTE: Int
+  description_LONGEST_LT: Int
+  description_LONGEST_LTE: Int
+  description_LT: Int
+  description_LTE: Int
+  description_SHORTEST_EQUAL: Int
+  description_SHORTEST_GT: Int
+  description_SHORTEST_GTE: Int
+  description_SHORTEST_LT: Int
+  description_SHORTEST_LTE: Int
+  id_EQUAL: ID
+  key_AVERAGE_EQUAL: Float
+  key_AVERAGE_GT: Float
+  key_AVERAGE_GTE: Float
+  key_AVERAGE_LT: Float
+  key_AVERAGE_LTE: Float
+  key_EQUAL: String
+  key_GT: Int
+  key_GTE: Int
+  key_LONGEST_EQUAL: Int
+  key_LONGEST_GT: Int
+  key_LONGEST_GTE: Int
+  key_LONGEST_LT: Int
+  key_LONGEST_LTE: Int
+  key_LT: Int
+  key_LTE: Int
+  key_SHORTEST_EQUAL: Int
+  key_SHORTEST_GT: Int
+  key_SHORTEST_GTE: Int
+  key_SHORTEST_LT: Int
+  key_SHORTEST_LTE: Int
+  name_AVERAGE_EQUAL: Float
+  name_AVERAGE_GT: Float
+  name_AVERAGE_GTE: Float
+  name_AVERAGE_LT: Float
+  name_AVERAGE_LTE: Float
+  name_EQUAL: String
+  name_GT: Int
+  name_GTE: Int
+  name_LONGEST_EQUAL: Int
+  name_LONGEST_GT: Int
+  name_LONGEST_GTE: Int
+  name_LONGEST_LT: Int
+  name_LONGEST_LTE: Int
+  name_LT: Int
+  name_LTE: Int
+  name_SHORTEST_EQUAL: Int
+  name_SHORTEST_GT: Int
+  name_SHORTEST_GTE: Int
+  name_SHORTEST_LT: Int
+  name_SHORTEST_LTE: Int
+  validationRules_AVERAGE_EQUAL: Float
+  validationRules_AVERAGE_GT: Float
+  validationRules_AVERAGE_GTE: Float
+  validationRules_AVERAGE_LT: Float
+  validationRules_AVERAGE_LTE: Float
+  validationRules_EQUAL: String
+  validationRules_GT: Int
+  validationRules_GTE: Int
+  validationRules_LONGEST_EQUAL: Int
+  validationRules_LONGEST_GT: Int
+  validationRules_LONGEST_GTE: Int
+  validationRules_LONGEST_LT: Int
+  validationRules_LONGEST_LTE: Int
+  validationRules_LT: Int
+  validationRules_LTE: Int
+  validationRules_SHORTEST_EQUAL: Int
+  validationRules_SHORTEST_GT: Int
+  validationRules_SHORTEST_GTE: Int
+  validationRules_SHORTEST_LT: Int
+  validationRules_SHORTEST_LTE: Int
 }
 
 input InterfaceTypeFieldsFieldInput {
   connect: [InterfaceTypeFieldsConnectFieldInput!]
+  connectOrCreate: [InterfaceTypeFieldsConnectOrCreateFieldInput!]
   create: [InterfaceTypeFieldsCreateFieldInput!]
+}
+
+input InterfaceTypeFieldsNodeAggregationWhereInput {
+  AND: [InterfaceTypeFieldsNodeAggregationWhereInput!]
+  OR: [InterfaceTypeFieldsNodeAggregationWhereInput!]
+  id_EQUAL: ID
+  name_AVERAGE_EQUAL: Float
+  name_AVERAGE_GT: Float
+  name_AVERAGE_GTE: Float
+  name_AVERAGE_LT: Float
+  name_AVERAGE_LTE: Float
+  name_EQUAL: String
+  name_GT: Int
+  name_GTE: Int
+  name_LONGEST_EQUAL: Int
+  name_LONGEST_GT: Int
+  name_LONGEST_GTE: Int
+  name_LONGEST_LT: Int
+  name_LONGEST_LTE: Int
+  name_LT: Int
+  name_LTE: Int
+  name_SHORTEST_EQUAL: Int
+  name_SHORTEST_GT: Int
+  name_SHORTEST_GTE: Int
+  name_SHORTEST_LT: Int
+  name_SHORTEST_LTE: Int
 }
 
 type InterfaceTypeFieldsRelationship implements Field {
@@ -10515,17 +11065,18 @@ type InterfaceTypeFieldsRelationship implements Field {
   id: ID!
   key: String!
   name: String
-  node: TypeBase!
+  node: BaseType!
   validationRules: String
 }
 
 input InterfaceTypeFieldsUpdateConnectionInput {
   edge: FieldUpdateInput
-  node: TypeBaseUpdateInput
+  node: BaseTypeUpdateInput
 }
 
 input InterfaceTypeFieldsUpdateFieldInput {
   connect: [InterfaceTypeFieldsConnectFieldInput!]
+  connectOrCreate: [InterfaceTypeFieldsConnectOrCreateFieldInput!]
   create: [InterfaceTypeFieldsCreateFieldInput!]
   delete: [InterfaceTypeFieldsDeleteFieldInput!]
   disconnect: [InterfaceTypeFieldsDisconnectFieldInput!]
@@ -10654,7 +11205,7 @@ input InterfaceTypeOwnerNodeAggregationWhereInput {
 input InterfaceTypeRelationInput {
   apiOfAtoms: [InterfaceTypeApiOfAtomsCreateFieldInput!]
   fields: [InterfaceTypeFieldsCreateFieldInput!]
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -10675,7 +11226,7 @@ input InterfaceTypeUpdateInput {
   fields: [InterfaceTypeFieldsUpdateFieldInput!]
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type InterfaceTypeUserOwnerAggregationSelection {
@@ -10723,10 +11274,31 @@ input InterfaceTypeWhere {
   Return InterfaceTypes where some of the related Atoms match this filter
   """
   apiOfAtoms_SOME: AtomWhere
+  fieldsAggregate: InterfaceTypeFieldsAggregateInput
   fieldsConnection_ALL: InterfaceTypeFieldsConnectionWhere
   fieldsConnection_NONE: InterfaceTypeFieldsConnectionWhere
   fieldsConnection_SINGLE: InterfaceTypeFieldsConnectionWhere
   fieldsConnection_SOME: InterfaceTypeFieldsConnectionWhere
+
+  """
+  Return InterfaceTypes where all of the related BaseTypes match this filter
+  """
+  fields_ALL: BaseTypeWhere
+
+  """
+  Return InterfaceTypes where none of the related BaseTypes match this filter
+  """
+  fields_NONE: BaseTypeWhere
+
+  """
+  Return InterfaceTypes where one of the related BaseTypes match this filter
+  """
+  fields_SINGLE: BaseTypeWhere
+
+  """
+  Return InterfaceTypes where some of the related BaseTypes match this filter
+  """
+  fields_SOME: BaseTypeWhere
   id: ID
   id_CONTAINS: ID
   id_ENDS_WITH: ID
@@ -10753,8 +11325,8 @@ input InterfaceTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: InterfaceTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -10767,7 +11339,7 @@ type InterfaceTypesConnection {
 """
 Allows picking a lambda
 """
-type LambdaType implements TypeBase {
+type LambdaType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -10780,9 +11352,9 @@ type LambdaType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type LambdaTypeAggregateSelection {
@@ -10792,11 +11364,11 @@ type LambdaTypeAggregateSelection {
 }
 
 input LambdaTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input LambdaTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input LambdaTypeConnectOrCreateWhere {
@@ -10811,15 +11383,15 @@ input LambdaTypeCreateInput {
   id: ID!
   kind: TypeKind! = LambdaType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input LambdaTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input LambdaTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type LambdaTypeEdge {
@@ -10946,7 +11518,7 @@ input LambdaTypeOwnerNodeAggregationWhereInput {
 }
 
 input LambdaTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -10965,7 +11537,7 @@ input LambdaTypeUniqueWhere {
 input LambdaTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type LambdaTypeUserOwnerAggregationSelection {
@@ -11014,8 +11586,8 @@ input LambdaTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: LambdaTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -11065,6 +11637,9 @@ type Mutation {
   createEnumTypes(
     input: [EnumTypeCreateInput!]!
   ): CreateEnumTypesMutationResponse!
+  createGetBaseTypesReturns(
+    input: [GetBaseTypesReturnCreateInput!]!
+  ): CreateGetBaseTypesReturnsMutationResponse!
   createHooks(input: [HookCreateInput!]!): CreateHooksMutationResponse!
   createInterfaceTypes(
     input: [InterfaceTypeCreateInput!]!
@@ -11154,6 +11729,7 @@ type Mutation {
     delete: EnumTypeDeleteInput
     where: EnumTypeWhere
   ): DeleteInfo!
+  deleteGetBaseTypesReturns(where: GetBaseTypesReturnWhere): DeleteInfo!
   deleteHooks(delete: HookDeleteInput, where: HookWhere): DeleteInfo!
   deleteInterfaceTypes(
     delete: InterfaceTypeDeleteInput
@@ -11340,6 +11916,10 @@ type Mutation {
     update: EnumTypeUpdateInput
     where: EnumTypeWhere
   ): UpdateEnumTypesMutationResponse!
+  updateGetBaseTypesReturns(
+    update: GetBaseTypesReturnUpdateInput
+    where: GetBaseTypesReturnWhere
+  ): UpdateGetBaseTypesReturnsMutationResponse!
   updateHooks(
     connect: HookConnectInput
     connectOrCreate: HookConnectOrCreateInput
@@ -12042,7 +12622,7 @@ input PageSort {
 """
 Allows picking a page from the list of pages
 """
-type PageType implements TypeBase {
+type PageType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -12055,9 +12635,9 @@ type PageType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type PageTypeAggregateSelection {
@@ -12067,11 +12647,11 @@ type PageTypeAggregateSelection {
 }
 
 input PageTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input PageTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input PageTypeConnectOrCreateWhere {
@@ -12086,15 +12666,15 @@ input PageTypeCreateInput {
   id: ID!
   kind: TypeKind! = PageType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input PageTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input PageTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type PageTypeEdge {
@@ -12221,7 +12801,7 @@ input PageTypeOwnerNodeAggregationWhereInput {
 }
 
 input PageTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -12240,7 +12820,7 @@ input PageTypeUniqueWhere {
 input PageTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type PageTypeUserOwnerAggregationSelection {
@@ -12289,8 +12869,8 @@ input PageTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: PageTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -12366,7 +12946,7 @@ type PagesConnection {
 """
 Base atomic building block of the type system. Represents primitive types - String, Integer, Float, Boolean
 """
-type PrimitiveType implements TypeBase {
+type PrimitiveType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -12379,9 +12959,9 @@ type PrimitiveType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
   primitiveKind: PrimitiveTypeKind!
 }
 
@@ -12392,11 +12972,11 @@ type PrimitiveTypeAggregateSelection {
 }
 
 input PrimitiveTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input PrimitiveTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input PrimitiveTypeConnectOrCreateWhere {
@@ -12411,16 +12991,16 @@ input PrimitiveTypeCreateInput {
   id: ID!
   kind: TypeKind! = PrimitiveType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
   primitiveKind: PrimitiveTypeKind!
 }
 
 input PrimitiveTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input PrimitiveTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type PrimitiveTypeEdge {
@@ -12554,7 +13134,7 @@ input PrimitiveTypeOwnerNodeAggregationWhereInput {
 }
 
 input PrimitiveTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -12576,7 +13156,7 @@ input PrimitiveTypeUniqueWhere {
 input PrimitiveTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
   primitiveKind: PrimitiveTypeKind
 }
 
@@ -12626,8 +13206,8 @@ input PrimitiveTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: PrimitiveTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
   primitiveKind: PrimitiveTypeKind
   primitiveKind_IN: [PrimitiveTypeKind!]
@@ -13486,6 +14066,7 @@ type Query {
     sort: [AtomSort]
     where: AtomWhere
   ): AtomsConnection!
+  baseTypes(options: GetBaseTypesOptions): GetBaseTypesReturn!
   codeActions(
     options: CodeActionOptions
     where: CodeActionWhere
@@ -13588,6 +14169,19 @@ type Query {
     sort: [EnumTypeSort]
     where: EnumTypeWhere
   ): EnumTypesConnection!
+  getBaseTypesReturns(
+    options: GetBaseTypesReturnOptions
+    where: GetBaseTypesReturnWhere
+  ): [GetBaseTypesReturn!]!
+  getBaseTypesReturnsAggregate(
+    where: GetBaseTypesReturnWhere
+  ): GetBaseTypesReturnAggregateSelection!
+  getBaseTypesReturnsConnection(
+    after: String
+    first: Int
+    sort: [GetBaseTypesReturnSort]
+    where: GetBaseTypesReturnWhere
+  ): GetBaseTypesReturnsConnection!
 
   """
   Returns a list of all Type and Atom entities that reference the type with the given id
@@ -13816,7 +14410,7 @@ Comparison between different element types:
 - ReactNodeType: Component select box, results it 'ReactNode' value
 - ElementType: Current tree element select box, results it 'ReactNode' value
 """
-type ReactNodeType implements TypeBase {
+type ReactNodeType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -13829,9 +14423,9 @@ type ReactNodeType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type ReactNodeTypeAggregateSelection {
@@ -13841,11 +14435,11 @@ type ReactNodeTypeAggregateSelection {
 }
 
 input ReactNodeTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input ReactNodeTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input ReactNodeTypeConnectOrCreateWhere {
@@ -13860,15 +14454,15 @@ input ReactNodeTypeCreateInput {
   id: ID!
   kind: TypeKind! = ReactNodeType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input ReactNodeTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input ReactNodeTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type ReactNodeTypeEdge {
@@ -13995,7 +14589,7 @@ input ReactNodeTypeOwnerNodeAggregationWhereInput {
 }
 
 input ReactNodeTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -14014,7 +14608,7 @@ input ReactNodeTypeUniqueWhere {
 input ReactNodeTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type ReactNodeTypeUserOwnerAggregationSelection {
@@ -14063,8 +14657,8 @@ input ReactNodeTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: ReactNodeTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -14085,7 +14679,7 @@ Comparison between different element types:
 - ReactNodeType: Component select box, results it 'ReactNode' value
 - ElementType: Current tree element select box, results it 'ReactNode' value
 """
-type RenderPropsType implements TypeBase {
+type RenderPropsType implements IBaseType {
   id: ID!
   kind: TypeKind!
   name: String!
@@ -14098,9 +14692,9 @@ type RenderPropsType implements TypeBase {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
 }
 
 type RenderPropsTypeAggregateSelection {
@@ -14110,11 +14704,11 @@ type RenderPropsTypeAggregateSelection {
 }
 
 input RenderPropsTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
 }
 
 input RenderPropsTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
 }
 
 input RenderPropsTypeConnectOrCreateWhere {
@@ -14129,15 +14723,15 @@ input RenderPropsTypeCreateInput {
   id: ID!
   kind: TypeKind! = RenderPropsType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
 }
 
 input RenderPropsTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
 }
 
 input RenderPropsTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
 }
 
 type RenderPropsTypeEdge {
@@ -14264,7 +14858,7 @@ input RenderPropsTypeOwnerNodeAggregationWhereInput {
 }
 
 input RenderPropsTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
 }
 
 """
@@ -14283,7 +14877,7 @@ input RenderPropsTypeUniqueWhere {
 input RenderPropsTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
 }
 
 type RenderPropsTypeUserOwnerAggregationSelection {
@@ -14332,8 +14926,8 @@ input RenderPropsTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: RenderPropsTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
 }
 
@@ -15993,375 +16587,6 @@ type TagsConnection {
   totalCount: Int!
 }
 
-interface TypeBase {
-  id: ID!
-  kind: TypeKind!
-  name: String!
-  owner(directed: Boolean = true, options: UserOptions, where: UserWhere): User!
-  ownerConnection(
-    after: String
-    directed: Boolean = true
-    first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
-}
-
-input TypeBaseConnectInput {
-  _on: TypeBaseImplementationsConnectInput
-  owner: TypeBaseOwnerConnectFieldInput
-}
-
-input TypeBaseConnectWhere {
-  node: TypeBaseWhere!
-}
-
-input TypeBaseCreateInput {
-  ActionType: ActionTypeCreateInput
-  AppType: AppTypeCreateInput
-  ArrayType: ArrayTypeCreateInput
-  CodeMirrorType: CodeMirrorTypeCreateInput
-  ElementType: ElementTypeCreateInput
-  EnumType: EnumTypeCreateInput
-  InterfaceType: InterfaceTypeCreateInput
-  LambdaType: LambdaTypeCreateInput
-  PageType: PageTypeCreateInput
-  PrimitiveType: PrimitiveTypeCreateInput
-  ReactNodeType: ReactNodeTypeCreateInput
-  RenderPropsType: RenderPropsTypeCreateInput
-  UnionType: UnionTypeCreateInput
-}
-
-input TypeBaseDeleteInput {
-  _on: TypeBaseImplementationsDeleteInput
-  owner: TypeBaseOwnerDeleteFieldInput
-}
-
-input TypeBaseDisconnectInput {
-  _on: TypeBaseImplementationsDisconnectInput
-  owner: TypeBaseOwnerDisconnectFieldInput
-}
-
-input TypeBaseImplementationsConnectInput {
-  ActionType: [ActionTypeConnectInput!]
-  AppType: [AppTypeConnectInput!]
-  ArrayType: [ArrayTypeConnectInput!]
-  CodeMirrorType: [CodeMirrorTypeConnectInput!]
-  ElementType: [ElementTypeConnectInput!]
-  EnumType: [EnumTypeConnectInput!]
-  InterfaceType: [InterfaceTypeConnectInput!]
-  LambdaType: [LambdaTypeConnectInput!]
-  PageType: [PageTypeConnectInput!]
-  PrimitiveType: [PrimitiveTypeConnectInput!]
-  ReactNodeType: [ReactNodeTypeConnectInput!]
-  RenderPropsType: [RenderPropsTypeConnectInput!]
-  UnionType: [UnionTypeConnectInput!]
-}
-
-input TypeBaseImplementationsDeleteInput {
-  ActionType: [ActionTypeDeleteInput!]
-  AppType: [AppTypeDeleteInput!]
-  ArrayType: [ArrayTypeDeleteInput!]
-  CodeMirrorType: [CodeMirrorTypeDeleteInput!]
-  ElementType: [ElementTypeDeleteInput!]
-  EnumType: [EnumTypeDeleteInput!]
-  InterfaceType: [InterfaceTypeDeleteInput!]
-  LambdaType: [LambdaTypeDeleteInput!]
-  PageType: [PageTypeDeleteInput!]
-  PrimitiveType: [PrimitiveTypeDeleteInput!]
-  ReactNodeType: [ReactNodeTypeDeleteInput!]
-  RenderPropsType: [RenderPropsTypeDeleteInput!]
-  UnionType: [UnionTypeDeleteInput!]
-}
-
-input TypeBaseImplementationsDisconnectInput {
-  ActionType: [ActionTypeDisconnectInput!]
-  AppType: [AppTypeDisconnectInput!]
-  ArrayType: [ArrayTypeDisconnectInput!]
-  CodeMirrorType: [CodeMirrorTypeDisconnectInput!]
-  ElementType: [ElementTypeDisconnectInput!]
-  EnumType: [EnumTypeDisconnectInput!]
-  InterfaceType: [InterfaceTypeDisconnectInput!]
-  LambdaType: [LambdaTypeDisconnectInput!]
-  PageType: [PageTypeDisconnectInput!]
-  PrimitiveType: [PrimitiveTypeDisconnectInput!]
-  ReactNodeType: [ReactNodeTypeDisconnectInput!]
-  RenderPropsType: [RenderPropsTypeDisconnectInput!]
-  UnionType: [UnionTypeDisconnectInput!]
-}
-
-input TypeBaseImplementationsUpdateInput {
-  ActionType: ActionTypeUpdateInput
-  AppType: AppTypeUpdateInput
-  ArrayType: ArrayTypeUpdateInput
-  CodeMirrorType: CodeMirrorTypeUpdateInput
-  ElementType: ElementTypeUpdateInput
-  EnumType: EnumTypeUpdateInput
-  InterfaceType: InterfaceTypeUpdateInput
-  LambdaType: LambdaTypeUpdateInput
-  PageType: PageTypeUpdateInput
-  PrimitiveType: PrimitiveTypeUpdateInput
-  ReactNodeType: ReactNodeTypeUpdateInput
-  RenderPropsType: RenderPropsTypeUpdateInput
-  UnionType: UnionTypeUpdateInput
-}
-
-input TypeBaseImplementationsWhere {
-  ActionType: ActionTypeWhere
-  AppType: AppTypeWhere
-  ArrayType: ArrayTypeWhere
-  CodeMirrorType: CodeMirrorTypeWhere
-  ElementType: ElementTypeWhere
-  EnumType: EnumTypeWhere
-  InterfaceType: InterfaceTypeWhere
-  LambdaType: LambdaTypeWhere
-  PageType: PageTypeWhere
-  PrimitiveType: PrimitiveTypeWhere
-  ReactNodeType: ReactNodeTypeWhere
-  RenderPropsType: RenderPropsTypeWhere
-  UnionType: UnionTypeWhere
-}
-
-input TypeBaseOptions {
-  limit: Int
-  offset: Int
-
-  """
-  Specify one or more TypeBaseSort objects to sort TypeBases by. The sorts will be applied in the order in which they are arranged in the array.
-  """
-  sort: [TypeBaseSort]
-}
-
-input TypeBaseOwnerAggregateInput {
-  AND: [TypeBaseOwnerAggregateInput!]
-  OR: [TypeBaseOwnerAggregateInput!]
-  count: Int
-  count_GT: Int
-  count_GTE: Int
-  count_LT: Int
-  count_LTE: Int
-  edge: TypeBaseOwnerEdgeAggregationWhereInput
-  node: TypeBaseOwnerNodeAggregationWhereInput
-}
-
-input TypeBaseOwnerConnectFieldInput {
-  connect: UserConnectInput
-  edge: OwnedByCreateInput!
-  where: UserConnectWhere
-}
-
-input TypeBaseOwnerConnectOrCreateFieldInput {
-  onCreate: TypeBaseOwnerConnectOrCreateFieldInputOnCreate!
-  where: UserConnectOrCreateWhere!
-}
-
-input TypeBaseOwnerConnectOrCreateFieldInputOnCreate {
-  edge: OwnedByCreateInput!
-  node: UserOnCreateInput!
-}
-
-type TypeBaseOwnerConnection {
-  edges: [TypeBaseOwnerRelationship!]!
-  pageInfo: PageInfo!
-  totalCount: Int!
-}
-
-input TypeBaseOwnerConnectionSort {
-  edge: OwnedBySort
-  node: UserSort
-}
-
-input TypeBaseOwnerConnectionWhere {
-  AND: [TypeBaseOwnerConnectionWhere!]
-  OR: [TypeBaseOwnerConnectionWhere!]
-  edge: OwnedByWhere
-  edge_NOT: OwnedByWhere
-  node: UserWhere
-  node_NOT: UserWhere
-}
-
-input TypeBaseOwnerCreateFieldInput {
-  edge: OwnedByCreateInput!
-  node: UserCreateInput!
-}
-
-input TypeBaseOwnerDeleteFieldInput {
-  delete: UserDeleteInput
-  where: TypeBaseOwnerConnectionWhere
-}
-
-input TypeBaseOwnerDisconnectFieldInput {
-  disconnect: UserDisconnectInput
-  where: TypeBaseOwnerConnectionWhere
-}
-
-input TypeBaseOwnerEdgeAggregationWhereInput {
-  AND: [TypeBaseOwnerEdgeAggregationWhereInput!]
-  OR: [TypeBaseOwnerEdgeAggregationWhereInput!]
-  data_AVERAGE_EQUAL: Float
-  data_AVERAGE_GT: Float
-  data_AVERAGE_GTE: Float
-  data_AVERAGE_LT: Float
-  data_AVERAGE_LTE: Float
-  data_EQUAL: String
-  data_GT: Int
-  data_GTE: Int
-  data_LONGEST_EQUAL: Int
-  data_LONGEST_GT: Int
-  data_LONGEST_GTE: Int
-  data_LONGEST_LT: Int
-  data_LONGEST_LTE: Int
-  data_LT: Int
-  data_LTE: Int
-  data_SHORTEST_EQUAL: Int
-  data_SHORTEST_GT: Int
-  data_SHORTEST_GTE: Int
-  data_SHORTEST_LT: Int
-  data_SHORTEST_LTE: Int
-}
-
-input TypeBaseOwnerFieldInput {
-  connect: TypeBaseOwnerConnectFieldInput
-  connectOrCreate: TypeBaseOwnerConnectOrCreateFieldInput
-  create: TypeBaseOwnerCreateFieldInput
-}
-
-input TypeBaseOwnerNodeAggregationWhereInput {
-  AND: [TypeBaseOwnerNodeAggregationWhereInput!]
-  OR: [TypeBaseOwnerNodeAggregationWhereInput!]
-  auth0Id_AVERAGE_EQUAL: Float
-  auth0Id_AVERAGE_GT: Float
-  auth0Id_AVERAGE_GTE: Float
-  auth0Id_AVERAGE_LT: Float
-  auth0Id_AVERAGE_LTE: Float
-  auth0Id_EQUAL: String
-  auth0Id_GT: Int
-  auth0Id_GTE: Int
-  auth0Id_LONGEST_EQUAL: Int
-  auth0Id_LONGEST_GT: Int
-  auth0Id_LONGEST_GTE: Int
-  auth0Id_LONGEST_LT: Int
-  auth0Id_LONGEST_LTE: Int
-  auth0Id_LT: Int
-  auth0Id_LTE: Int
-  auth0Id_SHORTEST_EQUAL: Int
-  auth0Id_SHORTEST_GT: Int
-  auth0Id_SHORTEST_GTE: Int
-  auth0Id_SHORTEST_LT: Int
-  auth0Id_SHORTEST_LTE: Int
-  email_AVERAGE_EQUAL: Float
-  email_AVERAGE_GT: Float
-  email_AVERAGE_GTE: Float
-  email_AVERAGE_LT: Float
-  email_AVERAGE_LTE: Float
-  email_EQUAL: String
-  email_GT: Int
-  email_GTE: Int
-  email_LONGEST_EQUAL: Int
-  email_LONGEST_GT: Int
-  email_LONGEST_GTE: Int
-  email_LONGEST_LT: Int
-  email_LONGEST_LTE: Int
-  email_LT: Int
-  email_LTE: Int
-  email_SHORTEST_EQUAL: Int
-  email_SHORTEST_GT: Int
-  email_SHORTEST_GTE: Int
-  email_SHORTEST_LT: Int
-  email_SHORTEST_LTE: Int
-  id_EQUAL: ID
-  username_AVERAGE_EQUAL: Float
-  username_AVERAGE_GT: Float
-  username_AVERAGE_GTE: Float
-  username_AVERAGE_LT: Float
-  username_AVERAGE_LTE: Float
-  username_EQUAL: String
-  username_GT: Int
-  username_GTE: Int
-  username_LONGEST_EQUAL: Int
-  username_LONGEST_GT: Int
-  username_LONGEST_GTE: Int
-  username_LONGEST_LT: Int
-  username_LONGEST_LTE: Int
-  username_LT: Int
-  username_LTE: Int
-  username_SHORTEST_EQUAL: Int
-  username_SHORTEST_GT: Int
-  username_SHORTEST_GTE: Int
-  username_SHORTEST_LT: Int
-  username_SHORTEST_LTE: Int
-}
-
-type TypeBaseOwnerRelationship implements OwnedBy {
-  cursor: String!
-  data: String!
-  node: User!
-}
-
-input TypeBaseOwnerUpdateConnectionInput {
-  edge: OwnedByUpdateInput
-  node: UserUpdateInput
-}
-
-input TypeBaseOwnerUpdateFieldInput {
-  connect: TypeBaseOwnerConnectFieldInput
-  connectOrCreate: TypeBaseOwnerConnectOrCreateFieldInput
-  create: TypeBaseOwnerCreateFieldInput
-  delete: TypeBaseOwnerDeleteFieldInput
-  disconnect: TypeBaseOwnerDisconnectFieldInput
-  update: TypeBaseOwnerUpdateConnectionInput
-  where: TypeBaseOwnerConnectionWhere
-}
-
-"""
-Fields to sort TypeBases by. The order in which sorts are applied is not guaranteed when specifying many fields in one TypeBaseSort object.
-"""
-input TypeBaseSort {
-  id: SortDirection
-  kind: SortDirection
-  name: SortDirection
-}
-
-input TypeBaseUpdateInput {
-  _on: TypeBaseImplementationsUpdateInput
-  id: ID
-  name: String
-  owner: TypeBaseOwnerUpdateFieldInput
-}
-
-input TypeBaseWhere {
-  _on: TypeBaseImplementationsWhere
-  id: ID
-  id_CONTAINS: ID
-  id_ENDS_WITH: ID
-  id_IN: [ID!]
-  id_NOT: ID
-  id_NOT_CONTAINS: ID
-  id_NOT_ENDS_WITH: ID
-  id_NOT_IN: [ID!]
-  id_NOT_STARTS_WITH: ID
-  id_STARTS_WITH: ID
-  kind: TypeKind
-  kind_IN: [TypeKind!]
-  kind_NOT: TypeKind
-  kind_NOT_IN: [TypeKind!]
-  name: String
-  name_CONTAINS: String
-  name_ENDS_WITH: String
-  name_IN: [String!]
-  name_NOT: String
-  name_NOT_CONTAINS: String
-  name_NOT_ENDS_WITH: String
-  name_NOT_IN: [String!]
-  name_NOT_STARTS_WITH: String
-  name_STARTS_WITH: String
-  owner: UserWhere
-  ownerAggregate: TypeBaseOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
-  owner_NOT: UserWhere
-}
-
 enum TypeKind {
   ActionType
   AppType
@@ -16463,7 +16688,7 @@ type TypeReferencesConnection {
 """
 Allows picking one of a set of types
 """
-type UnionType implements TypeBase & WithDescendants {
+type UnionType implements IBaseType & WithDescendants {
   descendantTypesIds: [ID!]!
   id: ID!
   kind: TypeKind!
@@ -16477,9 +16702,9 @@ type UnionType implements TypeBase & WithDescendants {
     after: String
     directed: Boolean = true
     first: Int
-    sort: [TypeBaseOwnerConnectionSort!]
-    where: TypeBaseOwnerConnectionWhere
-  ): TypeBaseOwnerConnection!
+    sort: [IBaseTypeOwnerConnectionSort!]
+    where: IBaseTypeOwnerConnectionWhere
+  ): IBaseTypeOwnerConnection!
   typesOfUnionType(
     directed: Boolean = true
     options: QueryOptions
@@ -16500,12 +16725,12 @@ type UnionTypeAggregateSelection {
 }
 
 input UnionTypeConnectInput {
-  owner: TypeBaseOwnerConnectFieldInput
+  owner: IBaseTypeOwnerConnectFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeConnectInput
 }
 
 input UnionTypeConnectOrCreateInput {
-  owner: TypeBaseOwnerConnectOrCreateFieldInput
+  owner: IBaseTypeOwnerConnectOrCreateFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeConnectOrCreateInput
 }
 
@@ -16521,17 +16746,17 @@ input UnionTypeCreateInput {
   id: ID!
   kind: TypeKind! = UnionType
   name: String!
-  owner: TypeBaseOwnerFieldInput
+  owner: IBaseTypeOwnerFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeCreateInput
 }
 
 input UnionTypeDeleteInput {
-  owner: TypeBaseOwnerDeleteFieldInput
+  owner: IBaseTypeOwnerDeleteFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeDeleteInput
 }
 
 input UnionTypeDisconnectInput {
-  owner: TypeBaseOwnerDisconnectFieldInput
+  owner: IBaseTypeOwnerDisconnectFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeDisconnectInput
 }
 
@@ -16659,7 +16884,7 @@ input UnionTypeOwnerNodeAggregationWhereInput {
 }
 
 input UnionTypeRelationInput {
-  owner: TypeBaseOwnerCreateFieldInput
+  owner: IBaseTypeOwnerCreateFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeCreateFieldInput
 }
 
@@ -17534,7 +17759,7 @@ input UnionTypeUniqueWhere {
 input UnionTypeUpdateInput {
   id: ID
   name: String
-  owner: TypeBaseOwnerUpdateFieldInput
+  owner: IBaseTypeOwnerUpdateFieldInput
   typesOfUnionType: UnionTypeTypesOfUnionTypeUpdateInput
 }
 
@@ -17584,8 +17809,8 @@ input UnionTypeWhere {
   name_STARTS_WITH: String
   owner: UserWhere
   ownerAggregate: UnionTypeOwnerAggregateInput
-  ownerConnection: TypeBaseOwnerConnectionWhere
-  ownerConnection_NOT: TypeBaseOwnerConnectionWhere
+  ownerConnection: IBaseTypeOwnerConnectionWhere
+  ownerConnection_NOT: IBaseTypeOwnerConnectionWhere
   owner_NOT: UserWhere
   typesOfUnionTypeConnection_ALL: UnionTypeTypesOfUnionTypeConnectionWhere
   typesOfUnionTypeConnection_NONE: UnionTypeTypesOfUnionTypeConnectionWhere
@@ -17682,6 +17907,11 @@ type UpdateEnumTypeValuesMutationResponse {
 
 type UpdateEnumTypesMutationResponse {
   enumTypes: [EnumType!]!
+  info: UpdateInfo!
+}
+
+type UpdateGetBaseTypesReturnsMutationResponse {
+  getBaseTypesReturns: [GetBaseTypesReturn!]!
   info: UpdateInfo!
 }
 
@@ -17846,9 +18076,13 @@ type User {
   ): UserTagsConnection!
   types(
     directed: Boolean = true
-    options: TypeBaseOptions
-    where: TypeBaseWhere
-  ): [TypeBase!]!
+    options: BaseTypeOptions
+    where: BaseTypeWhere
+  ): [BaseType!]!
+  typesAggregate(
+    directed: Boolean = true
+    where: BaseTypeWhere
+  ): UserBaseTypeTypesAggregationSelection
   typesConnection(
     after: String
     directed: Boolean = true
@@ -18003,6 +18237,21 @@ input UserAppsUpdateFieldInput {
   disconnect: [UserAppsDisconnectFieldInput!]
   update: UserAppsUpdateConnectionInput
   where: UserAppsConnectionWhere
+}
+
+type UserBaseTypeTypesAggregationSelection {
+  count: Int!
+  edge: UserBaseTypeTypesEdgeAggregateSelection
+  node: UserBaseTypeTypesNodeAggregateSelection
+}
+
+type UserBaseTypeTypesEdgeAggregateSelection {
+  data: StringAggregateSelectionNonNullable!
+}
+
+type UserBaseTypeTypesNodeAggregateSelection {
+  id: IDAggregateSelectionNonNullable!
+  name: StringAggregateSelectionNonNullable!
 }
 
 type UserComponentComponentsAggregationSelection {
@@ -18578,10 +18827,32 @@ input UserTagsUpdateFieldInput {
   where: UserTagsConnectionWhere
 }
 
+input UserTypesAggregateInput {
+  AND: [UserTypesAggregateInput!]
+  OR: [UserTypesAggregateInput!]
+  count: Int
+  count_GT: Int
+  count_GTE: Int
+  count_LT: Int
+  count_LTE: Int
+  edge: UserTypesEdgeAggregationWhereInput
+  node: UserTypesNodeAggregationWhereInput
+}
+
 input UserTypesConnectFieldInput {
-  connect: TypeBaseConnectInput
+  connect: [BaseTypeConnectInput!]
   edge: OwnedByCreateInput!
-  where: TypeBaseConnectWhere
+  where: BaseTypeConnectWhere
+}
+
+input UserTypesConnectOrCreateFieldInput {
+  onCreate: UserTypesConnectOrCreateFieldInputOnCreate!
+  where: BaseTypeConnectOrCreateWhere!
+}
+
+input UserTypesConnectOrCreateFieldInputOnCreate {
+  edge: OwnedByCreateInput!
+  node: BaseTypeOnCreateInput!
 }
 
 type UserTypesConnection {
@@ -18592,7 +18863,7 @@ type UserTypesConnection {
 
 input UserTypesConnectionSort {
   edge: OwnedBySort
-  node: TypeBaseSort
+  node: BaseTypeSort
 }
 
 input UserTypesConnectionWhere {
@@ -18600,43 +18871,96 @@ input UserTypesConnectionWhere {
   OR: [UserTypesConnectionWhere!]
   edge: OwnedByWhere
   edge_NOT: OwnedByWhere
-  node: TypeBaseWhere
-  node_NOT: TypeBaseWhere
+  node: BaseTypeWhere
+  node_NOT: BaseTypeWhere
 }
 
 input UserTypesCreateFieldInput {
   edge: OwnedByCreateInput!
-  node: TypeBaseCreateInput!
+  node: BaseTypeCreateInput!
 }
 
 input UserTypesDeleteFieldInput {
-  delete: TypeBaseDeleteInput
+  delete: BaseTypeDeleteInput
   where: UserTypesConnectionWhere
 }
 
 input UserTypesDisconnectFieldInput {
-  disconnect: TypeBaseDisconnectInput
+  disconnect: BaseTypeDisconnectInput
   where: UserTypesConnectionWhere
+}
+
+input UserTypesEdgeAggregationWhereInput {
+  AND: [UserTypesEdgeAggregationWhereInput!]
+  OR: [UserTypesEdgeAggregationWhereInput!]
+  data_AVERAGE_EQUAL: Float
+  data_AVERAGE_GT: Float
+  data_AVERAGE_GTE: Float
+  data_AVERAGE_LT: Float
+  data_AVERAGE_LTE: Float
+  data_EQUAL: String
+  data_GT: Int
+  data_GTE: Int
+  data_LONGEST_EQUAL: Int
+  data_LONGEST_GT: Int
+  data_LONGEST_GTE: Int
+  data_LONGEST_LT: Int
+  data_LONGEST_LTE: Int
+  data_LT: Int
+  data_LTE: Int
+  data_SHORTEST_EQUAL: Int
+  data_SHORTEST_GT: Int
+  data_SHORTEST_GTE: Int
+  data_SHORTEST_LT: Int
+  data_SHORTEST_LTE: Int
 }
 
 input UserTypesFieldInput {
   connect: [UserTypesConnectFieldInput!]
+  connectOrCreate: [UserTypesConnectOrCreateFieldInput!]
   create: [UserTypesCreateFieldInput!]
+}
+
+input UserTypesNodeAggregationWhereInput {
+  AND: [UserTypesNodeAggregationWhereInput!]
+  OR: [UserTypesNodeAggregationWhereInput!]
+  id_EQUAL: ID
+  name_AVERAGE_EQUAL: Float
+  name_AVERAGE_GT: Float
+  name_AVERAGE_GTE: Float
+  name_AVERAGE_LT: Float
+  name_AVERAGE_LTE: Float
+  name_EQUAL: String
+  name_GT: Int
+  name_GTE: Int
+  name_LONGEST_EQUAL: Int
+  name_LONGEST_GT: Int
+  name_LONGEST_GTE: Int
+  name_LONGEST_LT: Int
+  name_LONGEST_LTE: Int
+  name_LT: Int
+  name_LTE: Int
+  name_SHORTEST_EQUAL: Int
+  name_SHORTEST_GT: Int
+  name_SHORTEST_GTE: Int
+  name_SHORTEST_LT: Int
+  name_SHORTEST_LTE: Int
 }
 
 type UserTypesRelationship implements OwnedBy {
   cursor: String!
   data: String!
-  node: TypeBase!
+  node: BaseType!
 }
 
 input UserTypesUpdateConnectionInput {
   edge: OwnedByUpdateInput
-  node: TypeBaseUpdateInput
+  node: BaseTypeUpdateInput
 }
 
 input UserTypesUpdateFieldInput {
   connect: [UserTypesConnectFieldInput!]
+  connectOrCreate: [UserTypesConnectOrCreateFieldInput!]
   create: [UserTypesCreateFieldInput!]
   delete: [UserTypesDeleteFieldInput!]
   disconnect: [UserTypesDisconnectFieldInput!]
@@ -18799,10 +19123,31 @@ input UserWhere {
   Return Users where some of the related Tags match this filter
   """
   tags_SOME: TagWhere
+  typesAggregate: UserTypesAggregateInput
   typesConnection_ALL: UserTypesConnectionWhere
   typesConnection_NONE: UserTypesConnectionWhere
   typesConnection_SINGLE: UserTypesConnectionWhere
   typesConnection_SOME: UserTypesConnectionWhere
+
+  """
+  Return Users where all of the related BaseTypes match this filter
+  """
+  types_ALL: BaseTypeWhere
+
+  """
+  Return Users where none of the related BaseTypes match this filter
+  """
+  types_NONE: BaseTypeWhere
+
+  """
+  Return Users where one of the related BaseTypes match this filter
+  """
+  types_SINGLE: BaseTypeWhere
+
+  """
+  Return Users where some of the related BaseTypes match this filter
+  """
+  types_SOME: BaseTypeWhere
   username: String
   username_CONTAINS: String
   username_ENDS_WITH: String


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description 
- TypeBase should be a type, implement ITypeBase (should be created) because we can't return interface structure
- Other types implement ITypebase too

```graphql
  input GetBaseTypesOptions {
    limit: Int
    offset: Int
  }

  type GetBaseTypesReturn {
    items: [BaseType!]!
    totalCount: Int!
  }

query {
   baseTypes(
    options: GetBaseTypesOptions
   ):GetBaseTypesReturn!
}
```

```graphql
query ($options: GetBaseTypesOptions) {
	baseTypes(options: $options) {
		totalCount
		items {
	    id
			name
			kind
			owner {
				id
			}
		}
	}
}
```

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1820
