### PR TITLE
fix: element duplication, conversion into component, and moving between components

### DIFF
--- a/.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch
+++ b/.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch
@@ -1,0 +1,9 @@
+diff --git a/types/cypress-expect.d.ts b/types/cypress-expect.d.ts
+index 74f71a57de8168c246b66469016591f8ca5ff76b..362f02975e3d8d79351802ce79ebce4e892123db 100644
+--- a/types/cypress-expect.d.ts
++++ b/types/cypress-expect.d.ts
+@@ -1,3 +1,3 @@
+ // Cypress adds chai expect and assert to global
+-declare const expect: Chai.ExpectStatic
++// declare const expect: Chai.ExpectStatic
+ declare const assert: Chai.AssertStatic

--- a/apps/builder-e2e/src/e2e/component.cy.ts
+++ b/apps/builder-e2e/src/e2e/component.cy.ts
@@ -121,6 +121,7 @@ describe('Component CRUD', () => {
         .find('.ant-tree-switcher_close')
         .click()
 
+      cy.wait(200) // eslint-disable-line cypress/no-unnecessary-waiting
       cy.wrap(componentChildren)
         .each((child: ComponentChildData) => {
           const { name, atom } = child

--- a/apps/builder-e2e/src/e2e/component.cy.ts
+++ b/apps/builder-e2e/src/e2e/component.cy.ts
@@ -69,8 +69,8 @@ describe('Component CRUD', () => {
       })
       .then((apps) => {
         const app = apps[0]
-        const pageId = app.pages[0].id
-        cy.visit(`/apps/${app.id}/pages/${pageId}/builder`)
+        const pageId = app?.pages[0]?.id
+        cy.visit(`/apps/${app?.id}/pages/${pageId}/builder`)
         cy.getSpinner().should('not.exist')
       })
   })
@@ -121,14 +121,15 @@ describe('Component CRUD', () => {
         .find('.ant-tree-switcher_close')
         .click()
 
-      cy.wait(200) // eslint-disable-line cypress/no-unnecessary-waiting
       cy.wrap(componentChildren)
         .each((child: ComponentChildData) => {
           const { name, atom } = child
           cy.get(`[title="${NEW_COMP_NAME}"]`)
             .eq(2)
             .find('.ant-dropdown-trigger')
-            .rightclick({ force: true })
+            // .rightclick({ force: true })
+            .trigger('contextmenu')
+
           cy.contains(/Add child/).click({ force: true })
 
           cy.getModal().setFormFieldValue({

--- a/libs/frontend/abstract/core/src/domain/component/component.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/component/component.dto.interface.ts
@@ -10,6 +10,9 @@ export interface ICreateComponentDTO {
 
   // Allow for connection to existing interface
   api?: IInterfaceTypeRef | undefined
+
+  // Allow for connection to existing element
+  rootElementId?: string | undefined
 }
 
 export type IUpdateComponentDTO = Omit<

--- a/libs/frontend/abstract/core/src/domain/element/element-tree.interface.model.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element-tree.interface.model.ts
@@ -18,6 +18,7 @@ export interface IElementTree {
   getPathFromRoot(element: INode): Array<INode>
   element(id: string): Maybe<IElement>
   addElements(elements: Array<IElement>): IElementTree
+  removeElements(elements: Array<IElement>): IElementTree
 }
 
 export interface IElementTreeService {

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -86,6 +86,10 @@ export interface IElementService
     elementId: string
     targetElementId: string
   }): Promise<void>
+  moveElementToAnotherTree(props: {
+    elementId: string
+    targetElementId: string
+  }): Promise<void>
   detachElementFromElementTree(elemenId: string): Promise<void>
   moveElementAsFirstChild(props: {
     elementId: string

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -3,7 +3,7 @@ import {
   ElementUpdateInput,
   ElementWhere,
 } from '@codelab/shared/abstract/codegen'
-import { Maybe, Nullable } from '@codelab/shared/abstract/types'
+import { Maybe } from '@codelab/shared/abstract/types'
 import { ObjectMap, Ref } from 'mobx-keystone'
 import {
   ICacheService,
@@ -26,7 +26,6 @@ import {
   IUpdateElementDTO,
 } from './element.dto.interface'
 import { IElement, IElementRef } from './element.model.interface'
-import { IElementTree } from './element-tree.interface.model'
 
 /**
  * Used for modal input
@@ -103,8 +102,7 @@ export interface IElementService
   convertElementToComponent(
     element: IElement,
     auth0Id: IAuth0Id,
-    elementTree: Nullable<IElementTree>,
-  ): Promise<void>
+  ): Promise<Maybe<IElement>>
   element(id: string): Maybe<IElement>
   updateElementsPropTransformationJs(
     element: IElement,

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -87,6 +87,7 @@ export interface IElementService
     elementId: string
     targetElementId: string
   }): Promise<void>
+  detachElementFromElementTree(elemenId: string): Promise<void>
   moveElementAsFirstChild(props: {
     elementId: string
     parentElementId: string
@@ -95,11 +96,10 @@ export interface IElementService
     elementId: string
     targetElementId: string
   }): Promise<void>
-  duplicateElement(
+  cloneElement(
     target: IElement,
-    auth0Id: IAuth0Id,
-    elementTree: IElementTree | null,
-  ): Promise<void>
+    targetParent: IElement,
+  ): Promise<Array<IElement>>
   convertElementToComponent(
     element: IElement,
     auth0Id: IAuth0Id,

--- a/libs/frontend/abstract/core/src/ui/tree.interface.ts
+++ b/libs/frontend/abstract/core/src/ui/tree.interface.ts
@@ -13,4 +13,5 @@ export interface IBuilderDataNode extends DataNode {
   key: string | number
   title?: React.ReactNode
   children?: Array<IBuilderDataNode>
+  rootKey: string | null
 }

--- a/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
+++ b/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
@@ -3,7 +3,6 @@ import {
   IElementService,
   IElementTree,
 } from '@codelab/frontend/abstract/core'
-import { Element } from '@codelab/frontend/domain/element'
 import { Nullable } from '@codelab/shared/abstract/types'
 import { TreeProps } from 'antd/lib/tree'
 import {
@@ -22,53 +21,32 @@ export interface UseElementTreeDropProps {
  */
 export const useElementTreeDrop = (elementService: IElementService) => {
   const handleDrop: TreeProps<IBuilderDataNode>['onDrop'] = async (info) => {
-    const dragNodeId = info.dragNode.key.toString()
-    const dropNodeId = info.node.key.toString()
-    // Check if the dropNode lives at a different component
-    // If so, we need to deep clone the element into the other component
-    const dropElement = elementService.element(dropNodeId)
-    const dragElement = elementService.element(dragNodeId)
+    const dragElementId = info.dragNode.key.toString()
+    const dropElementId = info.node.key.toString()
+    const dragRootId = info.dragNode.rootKey?.toString()
+    const dropRootId = info.node.rootKey?.toString()
 
-    if (dropElement && dragElement) {
-      const dragTree = Element.getElementTree(dragElement)
-      const dropTree = Element.getElementTree(dropElement)
-      const dragRoot = dragTree?._root
-      const dropRoot = dropTree?._root
-
-      if (dropRoot && dragRoot) {
-        // If the root is not the same as the drop element, we need to clone the element or do we?
-        if (dropRoot.id !== dragRoot.id) {
-          if (dragElement.id === dragRoot.id) {
-            // If we are dragging the root, we need to clone the entire tree
-            return
-          }
-
-          await elementService.detachElementFromElementTree(dragElement.id)
-          dragTree.removeElements([dragElement, ...dragElement.descendants])
-
-          if (dropElement.children.length === 0) {
-            await elementService.attachElementAsFirstChild({
-              elementId: dragElement.id,
-              parentElementId: dropElement.id,
-            })
-          } else {
-            await elementService.attachElementAsNextSibling({
-              elementId: dragElement.id,
-              targetElementId: dropElement.children[0].id,
-            })
-          }
-
-          dropTree.addElements([dragElement, ...dragElement.descendants])
-
-          return
-        }
+    // check if the dropNode lives in a different component
+    // move the element into the other component
+    if (dragRootId !== dropRootId) {
+      if (dragElementId === dragRootId) {
+        // We can't move the root because the drag component
+        // can't stay without a root element
+        return
       }
+
+      void elementService.moveElementToAnotherTree({
+        elementId: dragElementId,
+        targetElementId: dropElementId,
+      })
+
+      return
     }
 
     if (shouldMoveElementAsFirstChild(info)) {
       void elementService.moveElementAsFirstChild({
-        elementId: dragNodeId,
-        parentElementId: dropNodeId,
+        elementId: dragElementId,
+        parentElementId: dropElementId,
       })
 
       return
@@ -76,8 +54,8 @@ export const useElementTreeDrop = (elementService: IElementService) => {
 
     if (shouldMoveElementAsNextSibling(info)) {
       void elementService.moveElementAsNextSibling({
-        elementId: dragNodeId,
-        targetElementId: dropNodeId,
+        elementId: dragElementId,
+        targetElementId: dropElementId,
       })
     }
 

--- a/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
+++ b/libs/frontend/domain/builder/src/hooks/useElementTreeDrop/useElementTreeDrop.ts
@@ -1,4 +1,9 @@
-import { IElementService, IElementTree } from '@codelab/frontend/abstract/core'
+import {
+  IBuilderDataNode,
+  IElementService,
+  IElementTree,
+} from '@codelab/frontend/abstract/core'
+import { Element } from '@codelab/frontend/domain/element'
 import { Nullable } from '@codelab/shared/abstract/types'
 import { TreeProps } from 'antd/lib/tree'
 import {
@@ -16,9 +21,49 @@ export interface UseElementTreeDropProps {
  * This can be optimized by batching data changes in the API
  */
 export const useElementTreeDrop = (elementService: IElementService) => {
-  const handleDrop: TreeProps['onDrop'] = (info) => {
+  const handleDrop: TreeProps<IBuilderDataNode>['onDrop'] = async (info) => {
     const dragNodeId = info.dragNode.key.toString()
     const dropNodeId = info.node.key.toString()
+    // Check if the dropNode lives at a different component
+    // If so, we need to deep clone the element into the other component
+    const dropElement = elementService.element(dropNodeId)
+    const dragElement = elementService.element(dragNodeId)
+
+    if (dropElement && dragElement) {
+      const dragTree = Element.getElementTree(dragElement)
+      const dropTree = Element.getElementTree(dropElement)
+      const dragRoot = dragTree?._root
+      const dropRoot = dropTree?._root
+
+      if (dropRoot && dragRoot) {
+        // If the root is not the same as the drop element, we need to clone the element or do we?
+        if (dropRoot.id !== dragRoot.id) {
+          if (dragElement.id === dragRoot.id) {
+            // If we are dragging the root, we need to clone the entire tree
+            return
+          }
+
+          await elementService.detachElementFromElementTree(dragElement.id)
+          dragTree.removeElements([dragElement, ...dragElement.descendants])
+
+          if (dropElement.children.length === 0) {
+            await elementService.attachElementAsFirstChild({
+              elementId: dragElement.id,
+              parentElementId: dropElement.id,
+            })
+          } else {
+            await elementService.attachElementAsNextSibling({
+              elementId: dragElement.id,
+              targetElementId: dropElement.children[0].id,
+            })
+          }
+
+          dropTree.addElements([dragElement, ...dragElement.descendants])
+
+          return
+        }
+      }
+    }
 
     if (shouldMoveElementAsFirstChild(info)) {
       void elementService.moveElementAsFirstChild({

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -65,12 +65,16 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
       )
     }
 
-    const onConvert = () => {
+    const onConvert = async () => {
       if (!user?.sub) {
         return
       }
 
-      return convertElementToComponent(element, user.sub, elementTree)
+      const createdElement = await convertElementToComponent(element, user.sub)
+
+      if (createdElement) {
+        elementTree?.addElements([createdElement])
+      }
     }
 
     const onEditComponent = () => {

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/ElementContextMenu.tsx
@@ -24,10 +24,7 @@ export type ElementContextMenuProps = {
 } & ContextMenuProps &
   Pick<
     IElementService,
-    | 'createModal'
-    | 'deleteModal'
-    | 'duplicateElement'
-    | 'convertElementToComponent'
+    'createModal' | 'deleteModal' | 'cloneElement' | 'convertElementToComponent'
   >
 
 /**
@@ -40,7 +37,7 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
     onBlur,
     createModal,
     deleteModal,
-    duplicateElement,
+    cloneElement,
     convertElementToComponent,
     elementTree,
   }) => {
@@ -58,12 +55,14 @@ export const ElementContextMenu = observer<ElementContextMenuProps>(
       return deleteModal.open(elementRef(element.id))
     }
 
-    const onDuplicate = () => {
-      if (!user?.sub) {
+    const onDuplicate = async () => {
+      if (!user?.sub || !element.parentElement) {
         return
       }
 
-      return duplicateElement(element, user.sub, elementTree)
+      elementTree?.addElements(
+        await cloneElement(element, element.parentElement),
+      )
     }
 
     const onConvert = () => {

--- a/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
+++ b/libs/frontend/domain/builder/src/sections/explorer-pane/builder-tree/BuilderTree.tsx
@@ -135,8 +135,7 @@ export const BuilderTree = observer<BuilderTreeProps>(
               elementContextMenuProps={{
                 createModal: elementService.createModal,
                 deleteModal: elementService.deleteModal,
-                duplicateElement:
-                  elementService.duplicateElement.bind(elementService),
+                cloneElement: elementService.cloneElement.bind(elementService),
                 convertElementToComponent:
                   elementService.convertElementToComponent.bind(elementService),
                 elementTree,

--- a/libs/frontend/domain/component/src/store/api.utils.ts
+++ b/libs/frontend/domain/component/src/store/api.utils.ts
@@ -7,11 +7,21 @@ import { v4 } from 'uuid'
 export const mapCreateInput = (
   input: ICreateComponentDTO,
 ): ComponentCreateInput => {
-  const { id = v4(), name, auth0Id } = input
+  const { id = v4(), name, auth0Id, rootElementId } = input
 
-  const rootElement: ComponentCreateInput['rootElement'] = {
+  const createRootElement: ComponentCreateInput['rootElement'] = {
     create: {
       node: makeCreateInput({ name }),
+    },
+  }
+
+  const connectRootElement: ComponentCreateInput['rootElement'] = {
+    connect: {
+      where: {
+        node: {
+          id: rootElementId,
+        },
+      },
     },
   }
 
@@ -28,7 +38,7 @@ export const mapCreateInput = (
   return {
     id,
     name,
-    rootElement,
+    rootElement: rootElementId ? connectRootElement : createRootElement,
     api,
     owner: connectOwner(auth0Id),
   }

--- a/libs/frontend/domain/component/src/store/component.service.ts
+++ b/libs/frontend/domain/component/src/store/component.service.ts
@@ -82,8 +82,10 @@ export class ComponentService
           children: [dataNode].filter((data): data is IBuilderDataNode =>
             Boolean(data),
           ),
+          rootKey: elementTree.root?.id ?? null,
         }
       }),
+      rootKey: null,
     }
   }
 

--- a/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentModal.tsx
+++ b/libs/frontend/domain/component/src/use-cases/create-component/CreateComponentModal.tsx
@@ -34,7 +34,7 @@ export const CreateComponentModal = observer<{
       title={<span css={tw`font-semibold`}>Create component</span>}
       visible={componentService.createModal.isOpen}
     >
-      <ModalForm.Form<ICreateComponentDTO>
+      <ModalForm.Form<Omit<ICreateComponentDTO, 'rootElementId'>>
         model={{
           auth0Id: user?.auth0Id,
         }}

--- a/libs/frontend/domain/component/src/use-cases/create-component/createComponentSchema.ts
+++ b/libs/frontend/domain/component/src/use-cases/create-component/createComponentSchema.ts
@@ -2,7 +2,9 @@ import { ICreateComponentDTO } from '@codelab/frontend/abstract/core'
 import { showFieldOnDev } from '@codelab/shared/utils'
 import { JSONSchemaType } from 'ajv'
 
-export const createComponentSchema: JSONSchemaType<ICreateComponentDTO> = {
+export const createComponentSchema: JSONSchemaType<
+  Omit<ICreateComponentDTO, 'rootElementId'>
+> = {
   title: 'Create Component Input',
   type: 'object',
   properties: {

--- a/libs/frontend/domain/component/src/use-cases/update-component/UpdateComponentForm.tsx
+++ b/libs/frontend/domain/component/src/use-cases/update-component/UpdateComponentForm.tsx
@@ -28,7 +28,7 @@ export const UpdateComponentForm = observer<UpdateComponentFormProps>(
     }
 
     return (
-      <Form<IUpdateComponentDTO>
+      <Form<Omit<IUpdateComponentDTO, 'rootElementId'>>
         autosave
         model={model}
         onSubmit={onSubmit}

--- a/libs/frontend/domain/component/src/use-cases/update-component/UpdateComponentModal.tsx
+++ b/libs/frontend/domain/component/src/use-cases/update-component/UpdateComponentModal.tsx
@@ -33,7 +33,7 @@ export const UpdateComponentModal = observer<{
       title={<span css={tw`font-semibold`}>Update component</span>}
       visible={componentService.updateModal.isOpen}
     >
-      <ModalForm.Form<IUpdateComponentDTO>
+      <ModalForm.Form<Omit<IUpdateComponentDTO, 'rootElementId'>>
         model={model}
         onSubmit={handleSubmit}
         onSubmitError={createNotificationHandler({

--- a/libs/frontend/domain/component/src/use-cases/update-component/createComponentSchema.ts
+++ b/libs/frontend/domain/component/src/use-cases/update-component/createComponentSchema.ts
@@ -1,7 +1,9 @@
 import { IUpdateComponentDTO } from '@codelab/frontend/abstract/core'
 import { JSONSchemaType } from 'ajv'
 
-export const updateComponentSchema: JSONSchemaType<IUpdateComponentDTO> = {
+export const updateComponentSchema: JSONSchemaType<
+  Omit<IUpdateComponentDTO, 'rootElementId'>
+> = {
   title: 'Create Component Input',
   type: 'object',
   properties: {

--- a/libs/frontend/domain/element/src/store/api.utils.ts
+++ b/libs/frontend/domain/element/src/store/api.utils.ts
@@ -53,11 +53,7 @@ export const makeCreateInput = (
   }
 }
 
-export const makeDuplicateInput = (
-  element: IElement,
-  parentId: string,
-  userId: string,
-): ElementCreateInput => {
+export const makeDuplicateInput = (element: IElement): ElementCreateInput => {
   const props: ElementCreateInput['props'] = element.props
     ? { create: { node: { data: element.props.jsonString } } }
     : undefined

--- a/libs/frontend/domain/element/src/store/element-tree.model.ts
+++ b/libs/frontend/domain/element/src/store/element-tree.model.ts
@@ -111,6 +111,15 @@ export class ElementTree
     return this
   }
 
+  @modelAction
+  removeElements(elements: Array<IElement>) {
+    elements.forEach((element) => {
+      this._elements.delete(element.id)
+    })
+
+    return this
+  }
+
   getPathFromRoot(selectedElement: IElement): Array<IElement> {
     const path = []
     let current: IElement | undefined = selectedElement

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -718,6 +718,7 @@ export class Element
     guiCss,
     renderAtomType,
     renderComponentType,
+    parentComponent,
     hooks,
     propMapBindings,
     props,
@@ -763,8 +764,8 @@ export class Element
       }
     }
 
-    this.parentComponent = renderComponentType
-      ? componentRef(renderComponentType.id)
+    this.parentComponent = parentComponent
+      ? componentRef(parentComponent.id)
       : null
     this.renderComponentType = renderComponentType
       ? componentRef(renderComponentType.id)

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -1,5 +1,6 @@
 import type {
   IAtom,
+  IBuilderDataNode,
   IComponent,
   IElement,
   IElementDTO,
@@ -369,7 +370,7 @@ export class Element
   }
 
   @computed
-  get antdNode() {
+  get antdNode(): IBuilderDataNode {
     return {
       key: this.id,
       title: this.label,
@@ -377,6 +378,7 @@ export class Element
       children: !this.renderComponentType?.current
         ? this.children.map((child) => child.antdNode)
         : [],
+      rootKey: getElementTree(this)?._root?.id ?? null,
     }
   }
 

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -546,6 +546,51 @@ element is new parentElement's first child
 
   @modelFlow
   @transaction
+  moveElementToAnotherTree = _async(function* (
+    this: ElementService,
+    {
+      elementId,
+      targetElementId,
+    }: Parameters<IElementService['moveElementToAnotherTree']>[0],
+  ) {
+    const element = this.element(elementId)
+    const targetElement = this.element(targetElementId)
+
+    if (!targetElement || !element) {
+      return
+    }
+
+    yield* _await(this.detachElementFromElementTree(element.id))
+
+    if (targetElement.children.length === 0) {
+      yield* _await(
+        this.attachElementAsFirstChild({
+          elementId: element.id,
+          parentElementId: targetElement.id,
+        }),
+      )
+    } else {
+      yield* _await(
+        this.attachElementAsNextSibling({
+          elementId: element.id,
+          targetElementId: targetElement.children[0].id,
+        }),
+      )
+    }
+
+    Element.getElementTree(element)?.removeElements([
+      element,
+      ...element.descendants,
+    ])
+
+    Element.getElementTree(targetElement)?.addElements([
+      element,
+      ...element.descendants,
+    ])
+  })
+
+  @modelFlow
+  @transaction
   deleteElementSubgraph = _async(function* (
     this: ElementService,
     root: IElementRef,

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -570,12 +570,13 @@ element is new parentElement's first child
         }),
       )
     } else {
-      yield* _await(
-        this.attachElementAsNextSibling({
-          elementId: element.id,
-          targetElementId: targetElement.children[0].id,
-        }),
-      )
+      targetElement.children[0]?.id &&
+        (yield* _await(
+          this.attachElementAsNextSibling({
+            elementId: element.id,
+            targetElementId: targetElement.children[0]?.id,
+          }),
+        ))
     }
 
     Element.getElementTree(element)?.removeElements([

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -87,12 +87,6 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       return withMaybeProviders(IntermediateChildren)
     })
 
-    // root element is not draggable
-    // assume root element doesn't have error
-    if (!element.parentElement) {
-      return React.createElement(Fragment, {}, Children)
-    }
-
     return React.createElement(
       ErrorBoundary,
       {
@@ -105,9 +99,12 @@ export const ElementWrapper = observer<ElementWrapperProps>(
           element.setRenderingError(null)
         },
       },
-      // If we have an array, wrap it in a fragment
-      Array.isArray(Children)
+      // root element is not draggable
+      !element.parentElement
+        ? React.createElement(Fragment, {}, Children)
+        : Array.isArray(Children)
         ? React.createElement(
+            // Wrap array of elements with a fragment
             Fragment,
             {},
             DraggableElement({ children: Children, element }),

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "concurrently": "7.0.0",
     "cross-env": "7.0.3",
     "css-loader": "5.2.6",
-    "cypress": "10.9.0",
+    "cypress": "10.10.0",
     "cypress-jest-adapter": "^0.1.1",
     "cypress-nextjs-auth0": "2.1.0",
     "cz-customizable": "6.3.0",
@@ -296,6 +296,8 @@
   },
   "resolutions": {
     "rxjs": "^6.6.3",
-    "cypress@10.9.0": "patch:cypress@npm:10.9.0#.yarn/patches/cypress-npm-10.9.0-7807fe85fd"
+    "cypress@10.9.0": "patch:cypress@npm:10.9.0#.yarn/patches/cypress-npm-10.9.0-7807fe85fd",
+    "cypress@10.10.0": "patch:cypress@npm%3A10.10.0#./.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch",
+    "cypress@*": "patch:cypress@npm%3A10.10.0#./.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13805,7 +13805,7 @@ __metadata:
     cross-fetch: 3.1.4
     css-loader: 5.2.6
     csv-parser: 3.0.0
-    cypress: 10.9.0
+    cypress: 10.10.0
     cypress-jest-adapter: ^0.1.1
     cypress-nextjs-auth0: 2.1.0
     cz-customizable: 6.3.0
@@ -15159,9 +15159,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:*":
-  version: 10.8.0
-  resolution: "cypress@npm:10.8.0"
+"cypress@npm:10.10.0":
+  version: 10.10.0
+  resolution: "cypress@npm:10.10.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -15207,13 +15207,13 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c052690049980e7721e6fca563b724fde839d87d83c1478dfe26ce7d230992717c2c4028e7157bfb39ec274473e51929f49e5aab6a23c2b25cde2a439b1c3cf9
+  checksum: 668a32534a527dba79754abbf98af176b80c539a12ec00058932ba2a19c794c7888323e59e738c30f726ad740c5451c31d02548a0cb7c1b1c8ad01c55a984ca2
   languageName: node
   linkType: hard
 
-"cypress@npm:10.9.0":
-  version: 10.9.0
-  resolution: "cypress@npm:10.9.0"
+"cypress@patch:cypress@npm%3A10.10.0#./.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch::locator=codelab%40workspace%3A.":
+  version: 10.10.0
+  resolution: "cypress@patch:cypress@npm%3A10.10.0#./.yarn/patches/cypress-npm-10.10.0-c25bdaa71e.patch::version=10.10.0&hash=13cd81&locator=codelab%40workspace%3A."
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -15259,59 +15259,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 79e3dccbb82d0b0c92bb8888682766a9738374f473cf2e9a04825a6b3dbe4420c57948cabaf757af0929192a8e61b7f08b32d7f6ee0c3cddf2736cf4f408edc1
-  languageName: node
-  linkType: hard
-
-"cypress@patch:cypress@npm:10.9.0#.yarn/patches/cypress-npm-10.9.0-7807fe85fd::locator=codelab%40workspace%3A.":
-  version: 10.9.0
-  resolution: "cypress@patch:cypress@npm%3A10.9.0#.yarn/patches/cypress-npm-10.9.0-7807fe85fd::version=10.9.0&hash=13cd81&locator=codelab%40workspace%3A."
-  dependencies:
-    "@cypress/request": ^2.88.10
-    "@cypress/xvfb": ^1.2.4
-    "@types/node": ^14.14.31
-    "@types/sinonjs__fake-timers": 8.1.1
-    "@types/sizzle": ^2.3.2
-    arch: ^2.2.0
-    blob-util: ^2.0.2
-    bluebird: ^3.7.2
-    buffer: ^5.6.0
-    cachedir: ^2.3.0
-    chalk: ^4.1.0
-    check-more-types: ^2.24.0
-    cli-cursor: ^3.1.0
-    cli-table3: ~0.6.1
-    commander: ^5.1.0
-    common-tags: ^1.8.0
-    dayjs: ^1.10.4
-    debug: ^4.3.2
-    enquirer: ^2.3.6
-    eventemitter2: 6.4.7
-    execa: 4.1.0
-    executable: ^4.1.1
-    extract-zip: 2.0.1
-    figures: ^3.2.0
-    fs-extra: ^9.1.0
-    getos: ^3.2.1
-    is-ci: ^3.0.0
-    is-installed-globally: ~0.4.0
-    lazy-ass: ^1.6.0
-    listr2: ^3.8.3
-    lodash: ^4.17.21
-    log-symbols: ^4.0.0
-    minimist: ^1.2.6
-    ospath: ^1.2.2
-    pretty-bytes: ^5.6.0
-    proxy-from-env: 1.0.0
-    request-progress: ^3.0.0
-    semver: ^7.3.2
-    supports-color: ^8.1.1
-    tmp: ~0.2.1
-    untildify: ^4.0.0
-    yauzl: ^2.10.0
-  bin:
-    cypress: bin/cypress
-  checksum: 8b6a3d4a83f5b4247e50640397091b20deda45edad858ebce9cee4ad116e57d757734df17415434e818bae18d1264b358cca7af8d767f65d13e6d2e49065f84f
+  checksum: c1879aae39ef6b863897932f8a7a5b5465924beec9fc59c1dd2adb06fc1fcb0f5929f4040beb4a8194fba82d2a29453b430a50f6e81bde345b9e9ab6bac794b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description (Optional)

TODO: 

- [x] fix element duplication regression.
- [x] fix moving elements between components.
- [x] fix converting elements to components.
- [x] fix lint errors
- [x] fix rendering error thrown when converting `first child element` to component.
- [x] ~~fix error thrown when deleting an element that is an instance of a component (created using `convert to component`)~~ known issue #1915 

## Related Issue(s)

Fixes #1913
Fixes #1918 based on https://github.com/codelab-app/builder/issues/1918#issuecomment-1275070169