### PR TITLE
fix: filter out props keys that are not defined in atom api

### DIFF
--- a/libs/frontend/abstract/core/src/constant.ts
+++ b/libs/frontend/abstract/core/src/constant.ts
@@ -35,3 +35,5 @@ export const STATE_PATH_TEMPLATE_REGEX = /\{\{[^}]+}}/g
 
 export const LAST_WORD_AFTER_DOT_REGEX = /\.\w+$/
 export const WORD_BEFORE_DOT_REGEX = /\w*(\.)?/
+
+export const CUSTOM_TEXT_PROP_KEY = 'customText'

--- a/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/element/element.service.interface.ts
@@ -20,7 +20,6 @@ import {
   IPropMapBinding,
   IUpdatePropMapBindingDTO,
 } from '../prop'
-import { IInterfaceType } from '../type'
 import { IAuth0Id } from '../user'
 import {
   ICreateElementDTO,
@@ -134,11 +133,6 @@ export interface IElementService
    * Get all descendant elements
    */
   getDescendants(root: IElementRef): Promise<Array<IElement>>
-  removeDeletedPropDataFromElements(
-    interfaceType: IInterfaceType,
-    propKey: string,
-  ): Promise<void>
-
   loadComponentTree(component: RenderedComponentFragment): {
     rootElement: IElement
     hydratedElements: Array<IElement>

--- a/libs/frontend/abstract/core/src/domain/prop/prop.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/prop/prop.dto.interface.ts
@@ -1,3 +1,8 @@
+import { Maybe } from '@codelab/shared/abstract/types'
+import { Ref } from 'mobx-keystone'
+import { IInterfaceType } from '../type'
 import { PropFragment } from './prop.fragment.graphql.gen'
 
-export type IPropDTO = PropFragment
+export type IPropDTO = PropFragment & {
+  apiRef: Maybe<Ref<IInterfaceType>>
+}

--- a/libs/frontend/abstract/core/src/domain/prop/prop.dto.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/prop/prop.dto.interface.ts
@@ -4,5 +4,5 @@ import { IInterfaceType } from '../type'
 import { PropFragment } from './prop.fragment.graphql.gen'
 
 export type IPropDTO = PropFragment & {
-  apiRef: Maybe<Ref<IInterfaceType>>
+  apiRef?: Maybe<Ref<IInterfaceType>>
 }

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -755,7 +755,7 @@ export class Element
 
     this.preRenderActionId = preRenderActionId
     this.postRenderActionId = postRenderActionId
-    this.props = props ? Prop.hydrate({ ...props, apiRef }) : null
+    this.props = props ? new Prop({ id: props.id, apiRef }) : null
     this.parentId = parent?.id ?? null
 
     this.nextSiblingId = nextSibling?.id ?? null

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -6,6 +6,7 @@ import type {
   IElementDTO,
   IElementTree,
   IHook,
+  IInterfaceType,
   IProp,
   IPropData,
   IPropDataByElementId,
@@ -20,6 +21,7 @@ import {
 } from '@codelab/frontend/abstract/core'
 import { atomRef } from '@codelab/frontend/domain/atom'
 import { Prop, PropMapBinding } from '@codelab/frontend/domain/prop'
+import { typeRef } from '@codelab/frontend/domain/type'
 import {
   componentRef,
   getElementService,
@@ -74,6 +76,10 @@ export const hydrate = ({
   renderIfPropKey,
   renderForEachPropKey,
 }: Omit<IElementDTO, '__typename'>) => {
+  const apiRef = renderAtomType
+    ? (typeRef(renderAtomType.api.id) as Ref<IInterfaceType>)
+    : undefined
+
   return new Element({
     id,
     name,
@@ -87,7 +93,7 @@ export const hydrate = ({
     atom: renderAtomType ? atomRef(renderAtomType.id) : null,
     preRenderActionId,
     postRenderActionId,
-    props: props ? Prop.hydrate(props) : null,
+    props: props ? Prop.hydrate({ ...props, apiRef }) : null,
     propTransformationJs,
     renderIfPropKey,
     renderForEachPropKey,
@@ -734,6 +740,12 @@ export class Element
     prevSibling,
     firstChild,
   }: Omit<IElementDTO, '__typename'>) {
+    const apiRef = renderAtomType
+      ? (typeRef(renderAtomType.api.id) as Ref<IInterfaceType>)
+      : undefined
+
+    console.log('apiRef', apiRef)
+
     this.id = id
     this.name = name ?? null
     this.customCss = customCss ?? null
@@ -745,7 +757,7 @@ export class Element
 
     this.preRenderActionId = preRenderActionId
     this.postRenderActionId = postRenderActionId
-    this.props = props ? new Prop({ id: props.id }) : null
+    this.props = props ? Prop.hydrate({ ...props, apiRef }) : null
     this.parentId = parent?.id ?? null
 
     this.nextSiblingId = nextSibling?.id ?? null
@@ -753,7 +765,7 @@ export class Element
     this.firstChildId = firstChild?.id ?? null
 
     if (props) {
-      this.props?.writeCache(props)
+      this.props?.writeCache({ ...props, apiRef })
     } else {
       this.props = null
     }

--- a/libs/frontend/domain/element/src/store/element.model.ts
+++ b/libs/frontend/domain/element/src/store/element.model.ts
@@ -744,8 +744,6 @@ export class Element
       ? (typeRef(renderAtomType.api.id) as Ref<IInterfaceType>)
       : undefined
 
-    console.log('apiRef', apiRef)
-
     this.id = id
     this.name = name ?? null
     this.customCss = customCss ?? null

--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -6,7 +6,6 @@ import {
   IElementDTO,
   IElementRef,
   IElementService,
-  IInterfaceType,
   isAtomDTO,
   isComponentDTO,
   IUpdateElementDTO,
@@ -27,7 +26,6 @@ import {
 import { IEntity } from '@codelab/shared/abstract/types'
 import { connectNode, reconnectNode } from '@codelab/shared/data'
 import { isNonNullable } from '@codelab/shared/utils'
-import omit from 'lodash/omit'
 import { computed } from 'mobx'
 import {
   _async,
@@ -871,36 +869,5 @@ element is new parentElement's first child
     element.removePropMapBinding(propMapBinding)
 
     return propMapBinding
-  })
-
-  /**
-   * If we change interface, the prop data should also be changed
-   */
-  @modelFlow
-  @transaction
-  removeDeletedPropDataFromElements = _async(function* (
-    this: ElementService,
-    interfaceType: IInterfaceType,
-    propKey: string,
-  ) {
-    const elementsThatUseTheProp = yield* _await(
-      this.getAll({ renderAtomType: { api: { id: interfaceType.id } } }),
-    )
-
-    const promises = elementsThatUseTheProp.map((element) => {
-      const updatedProps = omit(element.props?.data, propKey)
-
-      return this.patchElement(element, {
-        props: {
-          update: {
-            node: {
-              data: JSON.stringify(updatedProps),
-            },
-          },
-        },
-      })
-    })
-
-    yield* _await(Promise.all(promises))
   })
 }

--- a/libs/frontend/domain/element/src/use-cases/element/update-rich-text/UpdateRichTextForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-rich-text/UpdateRichTextForm.tsx
@@ -1,15 +1,14 @@
-import { UseTrackLoadingPromises } from '@codelab/frontend/view/components'
 import {
+  CUSTOM_TEXT_PROP_KEY,
   IElement,
   IElementService,
   IPropData,
 } from '@codelab/frontend/abstract/core'
+import { UseTrackLoadingPromises } from '@codelab/frontend/view/components'
 import { Col, Row } from 'antd'
 import { observer } from 'mobx-react-lite'
 import { useCallback, useState } from 'react'
 import ReactQuill from './ReactQuill'
-
-export const CUSTOM_TEXT_PROP_KEY = 'customText'
 
 export interface UpdateRichTextFormProps {
   elementService: IElementService
@@ -40,7 +39,7 @@ export const UpdateRichTextForm = observer<UpdateRichTextFormProps>(
     const { trackPromise } = trackPromises ?? {}
 
     const [value, setValue] = useState(
-      element.props?.values?.[CUSTOM_TEXT_PROP_KEY],
+      element.props?.values[CUSTOM_TEXT_PROP_KEY],
     )
 
     const inEditMode = useCallback(

--- a/libs/frontend/domain/prop/src/store/prop.model.ts
+++ b/libs/frontend/domain/prop/src/store/prop.model.ts
@@ -1,4 +1,5 @@
-import type {
+import {
+  CUSTOM_TEXT_PROP_KEY,
   IInterfaceType,
   IProp,
   IPropData,
@@ -42,10 +43,20 @@ export class Prop
       const apiPropsMap = this.apiRef.current.fields.items
 
       const apiPropsByKey = values(apiPropsMap)
-        .map((propModel) => ({ [propModel.key]: propModel }))
+        .map((propModel) => ({ [propModel.current.key]: propModel }))
         .reduce(merge, {})
 
-      return omitBy(this.data.data, (_, key) => !apiPropsByKey[key])
+      console.log('apiRef', this.apiRef.current.fieldsList, this.data.data)
+
+      return omitBy(this.data.data, (_, key) => {
+        // CUSTOM_TEXT_PROP_KEY is a special case, it's an element prop
+        // that is not part of the api
+        if (key === CUSTOM_TEXT_PROP_KEY) {
+          return false
+        }
+
+        return !apiPropsByKey[key]
+      })
     }
 
     return { ...this.data.data }

--- a/libs/frontend/domain/prop/src/store/prop.model.ts
+++ b/libs/frontend/domain/prop/src/store/prop.model.ts
@@ -40,13 +40,11 @@ export class Prop
   @computed
   get values() {
     if (this.apiRef) {
-      const apiPropsMap = this.apiRef.current.fields.items
+      const apiPropsMap = this.apiRef.current.fields
 
       const apiPropsByKey = values(apiPropsMap)
-        .map((propModel) => ({ [propModel.current.key]: propModel }))
+        .map((propModel) => ({ [propModel.key]: propModel }))
         .reduce(merge, {})
-
-      console.log('apiRef', this.apiRef.current.fieldsList, this.data.data)
 
       return omitBy(this.data.data, (_, key) => {
         // CUSTOM_TEXT_PROP_KEY is a special case, it's an element prop

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -1,5 +1,9 @@
-import { IElement, IPropData, IRenderer } from '@codelab/frontend/abstract/core'
-import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/domain/element'
+import {
+  CUSTOM_TEXT_PROP_KEY,
+  IElement,
+  IPropData,
+  IRenderer,
+} from '@codelab/frontend/abstract/core'
 import { Nullish } from '@codelab/shared/abstract/types'
 import { mergeProps } from '@codelab/shared/utils'
 import { jsx } from '@emotion/react'

--- a/libs/frontend/domain/renderer/src/test/renderAtomPipe.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/renderAtomPipe.spec.ts
@@ -1,5 +1,5 @@
+import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/abstract/core'
 import { atomRef } from '@codelab/frontend/domain/atom'
-import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/domain/element'
 import { render } from '@testing-library/react'
 import { AtomRenderPipe } from '../renderPipes/atomRenderPipe'
 import { setupTestForRenderer } from './setup/setupTest'

--- a/libs/frontend/domain/renderer/src/test/setup/setupTest.ts
+++ b/libs/frontend/domain/renderer/src/test/setup/setupTest.ts
@@ -1,6 +1,7 @@
 /// <reference types='jest'/>
 
 import {
+  CUSTOM_TEXT_PROP_KEY,
   IAtom,
   IComponent,
   IElement,
@@ -12,7 +13,6 @@ import {
 import { Atom, atomRef, AtomService } from '@codelab/frontend/domain/atom'
 import { Component, ComponentService } from '@codelab/frontend/domain/component'
 import {
-  CUSTOM_TEXT_PROP_KEY,
   Element,
   ElementService,
   ElementTree,

--- a/libs/frontend/domain/renderer/src/test/typedValueTranformers.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/typedValueTranformers.spec.ts
@@ -1,5 +1,8 @@
-import { IRenderOutput, TypedValue } from '@codelab/frontend/abstract/core'
-import { CUSTOM_TEXT_PROP_KEY } from '@codelab/frontend/domain/element'
+import {
+  CUSTOM_TEXT_PROP_KEY,
+  IRenderOutput,
+  TypedValue,
+} from '@codelab/frontend/abstract/core'
 import { render } from '@testing-library/react'
 import { setupTestForRenderer } from './setup/setupTest'
 

--- a/libs/frontend/domain/type/src/store/field.service.ts
+++ b/libs/frontend/domain/type/src/store/field.service.ts
@@ -133,12 +133,8 @@ export class FieldService
 
     return nodesDeleted
 
-    // yield* _await(
-    //   this.elementService.removeDeletedPropDataFromElements(
     //     interfaceType,
-    //     field.key,
-    //   ),
-    // )
+    // yield* _await(this.updateDefaults(interfaceId, null, field.key))
 
     // Returns current edges, not deleted edges
     // const deletedField =


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

This PR includes a frontend solution for removing props that are left over in elements props after deleting it from atom's api. Replaces existing solution that updates element element props after the prop is deleted from atom's api.

- [x] Move filtering out logic to the `Prop` model
- [x] Fix props not filtered when navigating back to the `Builder` tab after deleting prop from Atom API (filtered after page refresh)

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1758
