### PR TITLE
fix: page not rendered after clicking on Builder tab

### DIFF
--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
@@ -74,7 +74,7 @@ const PageRenderer: CodelabPage = observer(() => {
       componentService.loadRenderedComponentTree(component),
     )
 
-    const renderer = await appRenderService.addRenderer({
+    const renderer = appRenderService.addRenderer({
       id: pageId,
       pageTree: pageElementTree,
       appTree: null,

--- a/libs/frontend/domain/renderer/src/render.service.ts
+++ b/libs/frontend/domain/renderer/src/render.service.ts
@@ -1,14 +1,10 @@
 import type {
-  IBuilderService,
   IComponentService,
   IElementService,
-  IElementTree,
   IRenderer,
   IRenderService,
-  IStore,
   RendererProps,
 } from '@codelab/frontend/abstract/core'
-import type { Nullable } from '@codelab/shared/abstract/types'
 import { computed } from 'mobx'
 import { Model, model, modelAction, objectMap, prop, Ref } from 'mobx-keystone'
 import { Renderer } from './renderer.model'
@@ -47,6 +43,8 @@ export class RenderService
 
       return renderer
     }
+
+    existing.initForce(props.pageTree)
 
     return existing
   }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)
Fixes page content is not rendered after navigating from other sidebar tabs to the `Builder` tab.

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1929
