### PR TITLE
fix: stop element tree from re-rendering on mouse move

### DIFF
--- a/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
+++ b/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
@@ -6,8 +6,7 @@ import {
 import { Nullable } from '@codelab/shared/abstract/types'
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import React from 'react'
-import { useMouse } from 'react-use'
-import { calcDragPosition } from './draggableElement.util'
+import { calcDragPosition, useElementLayout } from './draggableElement.util'
 import { DraggedElementOverlay } from './DraggedElementOverlay'
 import { DragPositionIndicator } from './DragPositionIndicator'
 
@@ -18,7 +17,7 @@ export interface SortableItemProps {
 
 export const DraggableElement = ({ element, children }: SortableItemProps) => {
   const droppableNodeRef = React.useRef<Nullable<HTMLElement>>(null)
-  const { elY, elH } = useMouse(droppableNodeRef)
+  const elLayout = useElementLayout(droppableNodeRef)
 
   // Create a draggable for the element
   const {
@@ -43,7 +42,11 @@ export const DraggableElement = ({ element, children }: SortableItemProps) => {
   // Set dragPosition for DragEndEvent
   if (isOver && over) {
     const dragData: BuilderDropData = {
-      dragPosition: calcDragPosition(isOver, elY, elH),
+      dragPosition: calcDragPosition(
+        isOver,
+        elLayout.current.relativeMousePosition?.y ?? 0,
+        elLayout.current.size?.h ?? 0,
+      ),
     }
 
     over.data.current = {
@@ -61,7 +64,11 @@ export const DraggableElement = ({ element, children }: SortableItemProps) => {
   return (
     <div ref={setDroppableNodeRef} style={{ position: 'relative' }}>
       <DragPositionIndicator
-        dragPosition={calcDragPosition(isOver, elY, elH)}
+        dragPosition={calcDragPosition(
+          isOver,
+          elLayout.current.relativeMousePosition?.y ?? 0,
+          elLayout.current.size?.h ?? 0,
+        )}
       />
       <div
         ref={draggableNodeRefSetter}

--- a/libs/frontend/domain/renderer/src/element/draggableElement.util.ts
+++ b/libs/frontend/domain/renderer/src/element/draggableElement.util.ts
@@ -1,5 +1,65 @@
 import { DragPosition } from '@codelab/frontend/abstract/core'
-import { Maybe } from '@codelab/shared/abstract/types'
+import { Maybe, Nullable } from '@codelab/shared/abstract/types'
+import { RefObject, useEffect, useRef } from 'react'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface Size {
+  w: number
+  h: number
+}
+
+interface ElementLayout {
+  size: Nullable<Size>
+  relativeMousePosition: Nullable<Position>
+}
+
+/**
+ * Keeps track of the element's size and the mouse position relative
+ * to the top left corner of the bounding box around the element
+ * @param refElement
+ * @returns
+ */
+export const useElementLayout = (refElement: RefObject<Element>) => {
+  const refLayout = useRef<ElementLayout>({
+    size: null,
+    relativeMousePosition: null,
+  })
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      if (refElement.current) {
+        const {
+          left,
+          top,
+          width: w,
+          height: h,
+        } = refElement.current.getBoundingClientRect()
+
+        const posX = left + window.pageXOffset
+        const posY = top + window.pageYOffset
+
+        refLayout.current.relativeMousePosition = {
+          x: event.pageX - posX,
+          y: event.pageY - posY,
+        }
+
+        refLayout.current.size = { w, h }
+      }
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+    }
+  }, [refLayout, refElement])
+
+  return refLayout
+}
 
 export const calcDragPosition = (
   isOver: boolean,


### PR DESCRIPTION
## Description (Optional)

## Related Issue(s)

Fixes #1936
