### PR TITLE
refactor: refactor App provider tree to use Page model (#1785)

### DIFF
--- a/apps/builder-e2e/src/e2e/admin/assert.ts
+++ b/apps/builder-e2e/src/e2e/admin/assert.ts
@@ -5,11 +5,13 @@ import { AntdTag } from 'libs/shared/data/src/tag/antd-tags.data'
 import difference from 'lodash/difference'
 import * as path from 'path'
 
+const TIMEOUT = 140000
+
 export const seedData = () => {
   cy.log('yarn cli seed').exec(
     'yarn cli data seed --stage test --email cypress@codelab.app',
     {
-      timeout: 90000,
+      timeout: TIMEOUT,
     },
   )
   // .its('stdout')
@@ -28,7 +30,7 @@ export const importData = (file: string = DEFAULT_SEED_FILE_PATH) => {
     ` yarn cli data import --seedDataPath ${getFullPath(
       file,
     )} --skipUserData --skipSeedData false --email cypress@codelab.app`,
-    { timeout: 90000 },
+    { timeout: TIMEOUT },
   )
 }
 
@@ -37,7 +39,7 @@ export const exportAndAssert = (file = DEFAULT_SEED_FILE_PATH) => {
     `yarn cli data export --seedDataPath ${getFullPath(
       file,
     )} --skipUserData --skipSeedData false`,
-    { timeout: 90000 },
+    { timeout: TIMEOUT },
   )
 
   return cy.readFile(file).then((payload: ExportedData) => {

--- a/apps/builder-e2e/src/e2e/builder.cy.ts
+++ b/apps/builder-e2e/src/e2e/builder.cy.ts
@@ -17,13 +17,7 @@ const ELEMENT_COL_B = 'Col B'
 const ELEMENT_TEXT = 'Text'
 const ELEMENT_BUTTON = 'Button'
 
-interface ElementData {
-  name: string
-  atom?: string
-  parentElement: string
-}
-
-const elements: Array<ElementData> = [
+const elements = [
   { name: ELEMENT_CONTAINER, parentElement: ROOT_ELEMENT_NAME },
   { name: ELEMENT_ROW, parentElement: ELEMENT_CONTAINER },
   {
@@ -106,40 +100,7 @@ describe('Elements CRUD', () => {
 
   describe('create', () => {
     it('should be able to create elements', () => {
-      cy.wrap(elements).each((element: ElementData) => {
-        const { atom, name, parentElement } = element
-
-        cy.getSider()
-          .find('.ant-page-header-heading')
-          .getButton({ icon: 'plus' })
-          .click()
-
-        cy.getModal().findByLabelText('Name').type(name)
-
-        /**
-         * We skip this if parent element is root, since it is disabled and can't be accessed
-         */
-        if (parentElement !== ROOT_ELEMENT_NAME) {
-          cy.getModal().setFormFieldValue({
-            label: 'Parent element',
-            value: parentElement,
-            type: FIELD_TYPE.SELECT,
-          })
-        }
-
-        if (atom) {
-          cy.getModal().setFormFieldValue({
-            label: 'Atom',
-            value: atom,
-            type: FIELD_TYPE.SELECT,
-          })
-        }
-
-        cy.getModal()
-          .getModalAction(/Create/)
-          .click()
-        cy.getModal().should('not.exist', { timeout: 10000 })
-      })
+      cy.createElementTree(elements)
     })
 
     it.skip('should be able to view props', () => {

--- a/apps/builder-e2e/src/e2e/providersPage.cy.ts
+++ b/apps/builder-e2e/src/e2e/providersPage.cy.ts
@@ -1,0 +1,135 @@
+import {
+  APP_PAGE_NAME,
+  ROOT_ELEMENT_NAME,
+} from '@codelab/frontend/abstract/core'
+import { IAtomType } from '@codelab/shared/abstract/core'
+import { FIELD_TYPE } from '../support/antd/form'
+import { seedData } from './admin/assert'
+import { appName, appSlug, pageName, pageSlug } from './apps/app.data'
+
+const CONFIG_PROVIDER_NAME = 'ConfigProvider'
+const CARD_COMPONENT_NAME = 'Card Component'
+const INPUT_COMPONENT_NAME = 'Input Component'
+
+const mainPageElements = [
+  {
+    name: CARD_COMPONENT_NAME,
+    parentElement: ROOT_ELEMENT_NAME,
+    atom: IAtomType.AntDesignCard,
+  },
+  {
+    name: INPUT_COMPONENT_NAME,
+    parentElement: CARD_COMPONENT_NAME,
+    atom: IAtomType.AntDesignInput,
+  },
+]
+
+const openPageByName = (name: string) => {
+  cy.findByText(name).click()
+  cy.getSpinner().should('not.exist')
+  cy.findByText(ROOT_ELEMENT_NAME, { timeout: 30000 }).should('be.visible')
+}
+
+describe('_app page', () => {
+  before(() => {
+    cy.resetDatabase()
+    cy.login()
+    cy.visit('/apps')
+    cy.getSpinner().should('not.exist')
+
+    seedData()
+  })
+
+  it('should create _app page when app is created', () => {
+    cy.findAllByText(appName, { exact: true, timeout: 0 }).should('not.exist')
+
+    cy.getButton({ label: /Create App/ }).click()
+    cy.getModal().setFormFieldValue({ label: 'Name', value: appName })
+    cy.getModal().setFormFieldValue({ label: 'Slug', value: appSlug })
+    cy.getModal()
+      .getModalAction(/Create App/)
+      .click()
+    cy.getModal().should('not.exist')
+
+    cy.findByText(appName).click()
+    cy.findByText(APP_PAGE_NAME).should('exist')
+  })
+
+  it('should be able to add config provider atom to the _app page', () => {
+    openPageByName(APP_PAGE_NAME)
+
+    cy.getSider()
+      .find('.ant-page-header-heading')
+      .getButton({ icon: 'plus' })
+      .click()
+
+    cy.getModal().findByLabelText('Name').type(CONFIG_PROVIDER_NAME)
+    cy.getModal().setFormFieldValue({
+      label: 'Atom',
+      value: IAtomType.AntDesignConfigProvider,
+      type: FIELD_TYPE.SELECT,
+    })
+    cy.getModal()
+      .getModalAction(/Create/)
+      .click()
+    cy.getModal().should('not.exist')
+
+    cy.go('back')
+    cy.getSider().find('.ant-page-header-heading').should('be.visible')
+  })
+
+  it('should be able to create simple page', () => {
+    cy.getSider()
+      .find('.ant-page-header-heading')
+      .getButton({ icon: 'plus' })
+      .click()
+
+    cy.getModal().findByLabelText('Name').type(pageName)
+    cy.getModal().findByLabelText('Slug').type(pageSlug)
+    cy.getModal()
+      .getModalAction(/Create Page/)
+      .click()
+    cy.getModal().should('not.exist')
+
+    openPageByName(pageName)
+  })
+
+  it('should be able to add card and input atoms to the page', () => {
+    cy.createElementTree(mainPageElements)
+  })
+
+  it('should render the input in enabled state in builder and viewer', () => {
+    cy.get('#Builder .ant-card-body input').should('not.be.disabled')
+
+    cy.get('header .anticon-eye').click()
+    cy.get('header .anticon-tool', { timeout: 30000 }).should('be.visible')
+    cy.get('#render-root .ant-card-body input').should('not.be.disabled')
+
+    cy.go('back')
+    cy.go('back')
+  })
+
+  it('should be able to toggle "Component Disabled" AntDesignConfigProvider prop on _app page', () => {
+    openPageByName(APP_PAGE_NAME)
+
+    cy.findByText(CONFIG_PROVIDER_NAME).click()
+
+    cy.get(`[aria-label="setting"]`).click()
+    cy.findByLabelText(/Component Disabled/).click()
+
+    cy.waitForApiCalls()
+
+    cy.go('back')
+  })
+
+  it('should render the input in disabled state', () => {
+    openPageByName(pageName)
+
+    cy.get('#render-root .ant-card-body input').should('be.disabled')
+
+    cy.get('header .anticon-eye').click()
+    cy.get('header .anticon-tool', { timeout: 30000 }).should('be.visible')
+
+    cy.get('#render-root .ant-card-body input').should('be.disabled')
+  })
+})

--- a/apps/builder-e2e/src/support/builder/builder.command.ts
+++ b/apps/builder-e2e/src/support/builder/builder.command.ts
@@ -1,0 +1,45 @@
+import { ROOT_ELEMENT_NAME } from '@codelab/frontend/abstract/core'
+import { FIELD_TYPE } from '../antd/form'
+
+interface ElementData {
+  name: string
+  atom?: string
+  parentElement: string
+}
+
+export const createElementTree = (elements: Array<ElementData>) => {
+  return cy.wrap(elements).each((element: ElementData) => {
+    const { atom, name, parentElement } = element
+
+    cy.getSider()
+      .find('.ant-page-header-heading')
+      .getButton({ icon: 'plus' })
+      .click()
+
+    cy.getModal().findByLabelText('Name').type(name)
+
+    /**
+     * We skip this if parent element is root, since it is disabled and can't be accessed
+     */
+    if (parentElement !== ROOT_ELEMENT_NAME) {
+      cy.getModal().setFormFieldValue({
+        label: 'Parent element',
+        value: parentElement,
+        type: FIELD_TYPE.SELECT,
+      })
+    }
+
+    if (atom) {
+      cy.getModal().setFormFieldValue({
+        label: 'Atom',
+        value: atom,
+        type: FIELD_TYPE.SELECT,
+      })
+    }
+
+    cy.getModal()
+      .getModalAction(/Create/)
+      .click()
+    cy.getModal().should('not.exist', { timeout: 10000 })
+  })
+}

--- a/apps/builder-e2e/src/support/builder/builder.register.ts
+++ b/apps/builder-e2e/src/support/builder/builder.register.ts
@@ -1,0 +1,9 @@
+import { CypressCommand } from '../types'
+import { createElementTree } from './builder.command'
+
+export const builderCommands: Array<CypressCommand> = [
+  {
+    name: 'createElementTree',
+    fn: createElementTree,
+  },
+]

--- a/apps/builder-e2e/src/support/builder/index.ts
+++ b/apps/builder-e2e/src/support/builder/index.ts
@@ -1,0 +1,1 @@
+export * from './builder.register'

--- a/apps/builder-e2e/src/support/commands.ts
+++ b/apps/builder-e2e/src/support/commands.ts
@@ -1,5 +1,6 @@
 import '@testing-library/cypress/add-commands'
 import { auth0Commands } from './auth0/auth0.register'
+import { builderCommands } from './builder'
 import { databaseCommands } from './database'
 import { UICommands } from './entities'
 import { helpersCommands } from './helpers'
@@ -9,6 +10,7 @@ const commands = [
   ...databaseCommands,
   ...UICommands,
   ...auth0Commands,
+  ...builderCommands,
 ]
 
 for (const cmd of commands) {

--- a/apps/builder-e2e/src/support/helpers/graphql.commands.ts
+++ b/apps/builder-e2e/src/support/helpers/graphql.commands.ts
@@ -7,6 +7,11 @@ const interceptGraphQL = (
   cy.intercept('POST', '/api/graphql', interceptor)
 }
 
+const waitForApiCalls = () => {
+  cy.intercept('/api/*').as('graphqlQueries')
+  cy.wait('@graphqlQueries')
+}
+
 const hasOperationName = (
   req: CyHttpMessages.IncomingHttpRequest,
   operationName: string,
@@ -47,9 +52,11 @@ export const graphqlRequest = (
 export interface CypressGraphQLHelpersCommands {
   interceptGraphQL: typeof interceptGraphQL
   graphqlRequest: typeof graphqlRequest
+  waitForApiCalls: typeof waitForApiCalls
 }
 
 export const graphQLCommands: Array<CypressCommand> = [
   { name: 'interceptGraphQL', fn: interceptGraphQL },
   { name: 'graphqlRequest', fn: graphqlRequest },
+  { name: 'waitForApiCalls', fn: waitForApiCalls },
 ]

--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -5073,6 +5073,7 @@ export type Page = {
   name: Scalars['String']
   slug: Scalars['String']
   getServerSideProps?: Maybe<Scalars['String']>
+  isProvider: Scalars['Boolean']
   rootElement: Element
   rootElementAggregate?: Maybe<PageElementRootElementAggregationSelection>
   app: App
@@ -16037,6 +16038,7 @@ export type PageCreateInput = {
   name: Scalars['String']
   slug: Scalars['String']
   getServerSideProps?: InputMaybe<Scalars['String']>
+  isProvider?: Scalars['Boolean']
   rootElement?: InputMaybe<PageRootElementFieldInput>
   app?: InputMaybe<PageAppFieldInput>
 }
@@ -16056,6 +16058,7 @@ export type PageOnCreateInput = {
   name: Scalars['String']
   slug: Scalars['String']
   getServerSideProps?: InputMaybe<Scalars['String']>
+  isProvider?: Scalars['Boolean']
 }
 
 export type PageOptions = {
@@ -16312,6 +16315,7 @@ export type PageSort = {
   name?: InputMaybe<SortDirection>
   slug?: InputMaybe<SortDirection>
   getServerSideProps?: InputMaybe<SortDirection>
+  isProvider?: InputMaybe<SortDirection>
 }
 
 export type PageTypeConnectInput = {
@@ -16499,6 +16503,7 @@ export type PageUpdateInput = {
   name?: InputMaybe<Scalars['String']>
   slug?: InputMaybe<Scalars['String']>
   getServerSideProps?: InputMaybe<Scalars['String']>
+  isProvider?: InputMaybe<Scalars['Boolean']>
   rootElement?: InputMaybe<PageRootElementUpdateFieldInput>
   app?: InputMaybe<PageAppUpdateFieldInput>
 }
@@ -16546,6 +16551,8 @@ export type PageWhere = {
   getServerSideProps_NOT_STARTS_WITH?: InputMaybe<Scalars['String']>
   getServerSideProps_ENDS_WITH?: InputMaybe<Scalars['String']>
   getServerSideProps_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
+  isProvider?: InputMaybe<Scalars['Boolean']>
+  isProvider_NOT?: InputMaybe<Scalars['Boolean']>
   rootElement?: InputMaybe<ElementWhere>
   rootElement_NOT?: InputMaybe<ElementWhere>
   rootElementAggregate?: InputMaybe<PageRootElementAggregateInput>

--- a/libs/backend/infra/adapter/neo4j/src/schema/model/page.schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/model/page.schema.ts
@@ -9,6 +9,7 @@ export const pageSchema = gql`
       @relationship(type: "ROOT_PAGE_ELEMENT", direction: OUT)
     app: App! @relationship(type: "PAGES", direction: IN)
     getServerSideProps: String
+    isProvider: Boolean! @default(value: false)
   }
 
   extend type Page

--- a/libs/frontend/abstract/core/src/constant.ts
+++ b/libs/frontend/abstract/core/src/constant.ts
@@ -20,11 +20,6 @@ export const ROOT_ELEMENT_NAME = 'Body'
 
 export const COMPONENT_TREE_CONTAINER = 'components'
 
-export const ROOT_COMPONENT_ELEMENT_NAME = 'Component Root Element'
-export const PROVIDER_ROOT_ELEMENT_NAME = 'Provider Root Element'
-export const DETACHED_ROOT_ELEMENT_NAME = 'Detached Root Element'
-
-export const PROVIDER_TREE_PAGE_NAME = 'Provider Tree'
 export const STATE_PATH_TEMPLATE_START = '{{'
 export const STATE_PATH_TEMPLATE_START_REGEX = /\{\{/g
 // start bracket that is not closed with }}

--- a/libs/frontend/abstract/core/src/constant.ts
+++ b/libs/frontend/abstract/core/src/constant.ts
@@ -37,3 +37,13 @@ export const LAST_WORD_AFTER_DOT_REGEX = /\.\w+$/
 export const WORD_BEFORE_DOT_REGEX = /\w*(\.)?/
 
 export const CUSTOM_TEXT_PROP_KEY = 'customText'
+
+export const APP_PAGE_NAME = '_app'
+export const APP_PAGE_SLUG = '_app'
+export const DEFAULT_GET_SERVER_SIDE_PROPS = `async function (context) {
+  return {
+    props: {},
+    redirect: undefined,
+    notFound: false,
+  }
+}`

--- a/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql
@@ -44,7 +44,7 @@ fragment PageBuilderApp on App {
   owner {
     id
   }
-  pages(where: { id: $pageId }) {
+  pages(where: { OR: [{ id: $pageId }, { isProvider: true }] }) {
     id
     name
     slug
@@ -58,6 +58,7 @@ fragment PageBuilderApp on App {
     app {
       id
     }
+    isProvider
   }
   store {
     ...Store

--- a/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/app/app.fragment.graphql.gen.ts
@@ -44,6 +44,7 @@ export type PageBuilderAppFragment = {
     name: string
     slug: string
     getServerSideProps?: string | null
+    isProvider: boolean
     rootElement: {
       descendantElements: Array<ElementFragment>
     } & ElementFragment
@@ -104,7 +105,7 @@ export const PageBuilderAppFragmentDoc = gql`
     owner {
       id
     }
-    pages(where: { id: $pageId }) {
+    pages(where: { OR: [{ id: $pageId }, { isProvider: true }] }) {
       id
       name
       slug
@@ -118,6 +119,7 @@ export const PageBuilderAppFragmentDoc = gql`
       app {
         id
       }
+      isProvider
     }
     store {
       ...Store

--- a/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
@@ -24,5 +24,5 @@ export interface IRenderer {
   runPreAction(element: IElement): void
   getPostAction(element: IElement): Nullish<() => unknown>
   renderElement(element: IElement, extraProps?: IPropData): ReactElement
-  initForce(pageTree: IElementTree): void
+  initForce(pageTree: IElementTree, appTree?: Nullable<IElementTree>): void
 }

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql
@@ -10,4 +10,5 @@ fragment Page on Page {
     id
     name
   }
+  isProvider
 }

--- a/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.fragment.graphql.gen.ts
@@ -8,6 +8,7 @@ export type PageFragment = {
   name: string
   slug: string
   getServerSideProps?: string | null
+  isProvider: boolean
   app: { id: string }
   rootElement: { id: string; name?: string | null }
 }
@@ -25,6 +26,7 @@ export const PageFragmentDoc = gql`
       id
       name
     }
+    isProvider
   }
 `
 

--- a/libs/frontend/abstract/core/src/domain/page/page.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/page/page.model.interface.ts
@@ -14,4 +14,5 @@ export interface IPage
   toJson: IPropData
   rootElement: IEntity
   getServerSideProps: Nullish<string>
+  isProvider: boolean
 }

--- a/libs/frontend/abstract/types/src/pageType.ts
+++ b/libs/frontend/abstract/types/src/pageType.ts
@@ -11,7 +11,6 @@ export enum PageType {
   PageDetail = '/apps/[appId]/pages/[pageId]',
   PageBuilder = '/apps/[appId]/pages/[pageId]/builder',
   AppDetail = '/apps/[appId]',
-  AppProviderDetail = '/apps/[appId]/provider',
   ComponentDetail = '/components/[componentId]',
   ComponentList = '/components',
   ComponentDetailV2 = '/library/[libraryId]/component/[componentId]',

--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -192,6 +192,7 @@ export class AppService
         rootElement: {
           create: { node: { id: v4(), name: ROOT_ELEMENT_NAME } },
         },
+        isProvider: true,
       }
 
       return {

--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -1,10 +1,14 @@
 import {
+  APP_PAGE_NAME,
+  APP_PAGE_SLUG,
+  DEFAULT_GET_SERVER_SIDE_PROPS,
   IApp,
   IAppDTO,
   IAppService,
   ICreateAppDTO,
   IPageBuilderAppProps,
   IUpdateAppDTO,
+  ROOT_ELEMENT_NAME,
 } from '@codelab/frontend/abstract/core'
 import { getPageService } from '@codelab/frontend/domain/page'
 import {
@@ -174,30 +178,50 @@ export class AppService
   @modelFlow
   @transaction
   create = _async(function* (this: AppService, data: Array<ICreateAppDTO>) {
-    const input: Array<AppCreateInput> = data.map((app) => ({
-      id: app.id ?? v4(),
-      name: app.name,
-      owner: connectOwner(app.auth0Id),
-      slug: slugify(app.slug),
-      store: {
-        create: {
-          node: {
-            id: v4(),
-            name: `${app.name} Store`,
-            api: {
-              create: {
-                node: {
-                  id: v4(),
-                  name: `${app.name} Store API`,
-                  kind: ITypeKind.InterfaceType,
-                  owner: connectOwner(app.auth0Id),
+    const input: Array<AppCreateInput> = data.map((app) => {
+      const appId = app.id ?? v4()
+
+      const providerPage = {
+        id: v4(),
+        name: APP_PAGE_NAME,
+        slug: APP_PAGE_SLUG,
+        getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
+        app: {
+          connect: { where: { node: { id: appId } } },
+        },
+        rootElement: {
+          create: { node: { id: v4(), name: ROOT_ELEMENT_NAME } },
+        },
+      }
+
+      return {
+        id: appId,
+        name: app.name,
+        owner: connectOwner(app.auth0Id),
+        slug: slugify(app.slug),
+        store: {
+          create: {
+            node: {
+              id: v4(),
+              name: `${app.name} Store`,
+              api: {
+                create: {
+                  node: {
+                    id: v4(),
+                    name: `${app.name} Store API`,
+                    kind: ITypeKind.InterfaceType,
+                    owner: connectOwner(app.auth0Id),
+                  },
                 },
               },
             },
           },
         },
-      },
-    }))
+        pages: {
+          create: [{ node: providerPage }],
+        },
+      }
+    })
 
     const {
       createApps: { apps },

--- a/libs/frontend/domain/page/src/store/page.model.ts
+++ b/libs/frontend/domain/page/src/store/page.model.ts
@@ -34,6 +34,7 @@ const hydrate = (page: IPageDTO) => {
     rootElement: { id: page.rootElement.id },
     getServerSideProps: page.getServerSideProps,
     app: { id: page.app.id },
+    isProvider: page.isProvider,
   })
 }
 
@@ -46,6 +47,7 @@ export class Page
     slug: prop<string>(),
     rootElement: prop<IEntity>(),
     getServerSideProps: prop<Nullish<string>>(),
+    isProvider: prop<boolean>(),
   })
   implements IPage
 {
@@ -67,6 +69,7 @@ export class Page
     this.rootElement = page.rootElement
     this.app = page.app
     this.getServerSideProps = page.getServerSideProps
+    this.isProvider = page.isProvider
 
     return this
   }

--- a/libs/frontend/domain/page/src/use-cases/create-page/CreatePageModal.tsx
+++ b/libs/frontend/domain/page/src/use-cases/create-page/CreatePageModal.tsx
@@ -1,4 +1,8 @@
-import { ICreatePageDTO, IPageService } from '@codelab/frontend/abstract/core'
+import {
+  DEFAULT_GET_SERVER_SIDE_PROPS,
+  ICreatePageDTO,
+  IPageService,
+} from '@codelab/frontend/abstract/core'
 import { useCurrentAppId } from '@codelab/frontend/presenter/container'
 import { createNotificationHandler } from '@codelab/frontend/shared/utils'
 import { ModalForm } from '@codelab/frontend/view/components'
@@ -7,19 +11,16 @@ import React from 'react'
 import { AutoFields } from 'uniforms-antd'
 import { createPageSchema } from './createPageSchema'
 
-const getServerSideProps = `async function (context) {
-  return {
-    props: {},
-    redirect: undefined,
-    notFound: false,
-  }
-}`
-
 export const CreatePageModal = observer<{ pageService: IPageService }>(
   ({ pageService }) => {
     const currentAppId = useCurrentAppId()
     const isOpen = pageService.createModal.isOpen
-    const model = { appId: currentAppId, getServerSideProps }
+
+    const model = {
+      appId: currentAppId,
+      getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
+    }
+
     const onSubmit = (data: ICreatePageDTO) => pageService.create([data])
 
     const onSubmitError = createNotificationHandler({

--- a/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesItem.tsx
@@ -1,9 +1,5 @@
 import { FileOutlined } from '@ant-design/icons'
-import {
-  IPage,
-  IPageService,
-  PROVIDER_TREE_PAGE_NAME,
-} from '@codelab/frontend/abstract/core'
+import { IPage, IPageService } from '@codelab/frontend/abstract/core'
 import { PageType } from '@codelab/frontend/abstract/types'
 import {
   ListItemDeleteButton,
@@ -24,14 +20,11 @@ export interface GetPagesItemProps {
 export const GetPagesItem = observer<GetPagesItemProps>(
   ({ page, pageService }) => {
     const router = useRouter()
-    const isProviderTreePage = page.name === PROVIDER_TREE_PAGE_NAME
 
-    const href = isProviderTreePage
-      ? { pathname: PageType.AppProviderDetail, query: router.query }
-      : {
-          pathname: PageType.PageBuilder,
-          query: { ...router.query, pageId: page.id },
-        }
+    const href = {
+      pathname: PageType.PageBuilder,
+      query: { ...router.query, pageId: page.id },
+    }
 
     const onClickDelete = () => pageService.deleteModal.open(pageRef(page.id))
     const onClickEdit = () => pageService.updateModal.open(pageRef(page.id))
@@ -42,7 +35,7 @@ export const GetPagesItem = observer<GetPagesItemProps>(
           <FileOutlined />
           <Link href={href}>{page.name}</Link>
         </Space>
-        {!isProviderTreePage && (
+        {!page.isProvider && (
           <Space>
             <ListItemEditButton onClick={onClickEdit} />
             <ListItemDeleteButton onClick={onClickDelete} />

--- a/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesList.tsx
+++ b/libs/frontend/domain/page/src/use-cases/get-pages/GetPagesList.tsx
@@ -18,7 +18,6 @@ export const GetPagesList = observer<{ pageService: IPageService }>(
 
     // pageService.pagesList doesn't filter by app
     const pagesList = pageService.pagesByApp(appId)
-    // const results = pagesList.concat([{ name: PROVIDER_TREE_PAGE_NAME }])
 
     return (
       <Spinner isLoading={loading}>

--- a/libs/frontend/domain/renderer/src/render.service.ts
+++ b/libs/frontend/domain/renderer/src/render.service.ts
@@ -38,7 +38,7 @@ export class RenderService
       return renderer
     }
 
-    existing.initForce(props.pageTree)
+    existing.initForce(props.pageTree, props.appTree)
 
     return existing
   }

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -157,8 +157,12 @@ export class Renderer
   implements IRenderer
 {
   @modelAction
-  initForce(pageElementTree: IElementTree) {
+  initForce(
+    pageElementTree: IElementTree,
+    appElementTree: Nullable<IElementTree>,
+  ) {
     this.pageTree = elementTreeRef(pageElementTree)
+    this.appTree = appElementTree ? elementTreeRef(appElementTree) : null
   }
 
   renderRoot() {

--- a/libs/frontend/presenter/container/src/index.ts
+++ b/libs/frontend/presenter/container/src/index.ts
@@ -1,3 +1,4 @@
 export * from './context'
+export * from './pageHooks'
 export * from './providers'
 export * from './routerHooks'

--- a/libs/frontend/presenter/container/src/pageHooks/index.ts
+++ b/libs/frontend/presenter/container/src/pageHooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useLoadRenderedPage'

--- a/libs/frontend/presenter/container/src/pageHooks/useLoadRenderedPage.ts
+++ b/libs/frontend/presenter/container/src/pageHooks/useLoadRenderedPage.ts
@@ -1,0 +1,87 @@
+import { useAsync } from 'react-use'
+import { useStore } from '../providers'
+import { useCurrentAppId, useCurrentPageId } from '../routerHooks'
+
+/**
+ * Fetch related data for rendering page, and load them into store
+ */
+export const useLoadRenderedPage = () => {
+  const {
+    appService,
+    storeService,
+    typeService,
+    componentService,
+    resourceService,
+    pageService,
+  } = useStore()
+
+  const appId = useCurrentAppId()
+  const pageId = useCurrentPageId()
+
+  return useAsync(async () => {
+    const {
+      apps,
+      components,
+      resources,
+      // Can't change shape in GraphQL so we have to use this structure
+      primitiveTypes,
+      arrayTypes,
+      unionTypes,
+      interfaceTypes,
+      elementTypes,
+      renderPropsTypes,
+      reactNodeTypes,
+      enumTypes,
+      lambdaTypes,
+      pageTypes,
+      appTypes,
+      actionTypes,
+      codeMirrorTypes,
+    } = await pageService.getRenderedPage(appId, pageId)
+
+    const [app] = apps
+
+    if (!app) {
+      return null
+    }
+
+    const [currentPage, providerPage] = app.pages
+      .sort((page) => (page.isProvider ? 1 : -1))
+      .map((page) => appService.load({ app, pageId: page.id }))
+
+    if (!currentPage) {
+      return null
+    }
+
+    const { pageElementTree: pageTree, page } = currentPage
+    const { pageElementTree: appTree } = providerPage ?? {}
+
+    typeService.load({
+      primitiveTypes,
+      arrayTypes,
+      unionTypes,
+      interfaceTypes,
+      elementTypes,
+      renderPropsTypes,
+      reactNodeTypes,
+      enumTypes,
+      lambdaTypes,
+      pageTypes,
+      appTypes,
+      actionTypes,
+      codeMirrorTypes,
+    })
+
+    components.map((component) =>
+      componentService.loadRenderedComponentTree(component),
+    )
+
+    resources.map((resource) => resourceService.writeCache(resource))
+
+    // hydrate after types and resources
+    const appStore = storeService.writeCache(app.store)
+    appStore.state.setMany(appService.appsJson)
+
+    return { page, pageTree, appTree, appStore }
+  }, [])
+}

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -21409,6 +21409,7 @@ export type PageFragment = {
   name: string
   slug: string
   getServerSideProps?: string | null
+  isProvider?: boolean | null
   app: { __typename?: 'App'; id: string }
   rootElement: { __typename?: 'Element'; id: string; name?: string | null }
 }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -21299,6 +21299,7 @@ export type PageBuilderAppFragment = {
     name: string
     slug: string
     getServerSideProps?: string | null
+    isProvider: boolean
     rootElement: {
       __typename?: 'Element'
       descendantElements: Array<{ __typename?: 'Element' } & ElementFragment>
@@ -21409,7 +21410,7 @@ export type PageFragment = {
   name: string
   slug: string
   getServerSideProps?: string | null
-  isProvider?: boolean | null
+  isProvider: boolean
   app: { __typename?: 'App'; id: string }
   rootElement: { __typename?: 'Element'; id: string; name?: string | null }
 }

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -13157,6 +13157,7 @@ export type Page = {
   appConnection: PageAppConnection
   getServerSideProps?: Maybe<Scalars['String']>
   id: Scalars['ID']
+  isProvider: Scalars['Boolean']
   name: Scalars['String']
   rootElement: Element
   rootElementAggregate?: Maybe<PageElementRootElementAggregationSelection>
@@ -13375,6 +13376,7 @@ export type PageCreateInput = {
   app?: InputMaybe<PageAppFieldInput>
   getServerSideProps?: InputMaybe<Scalars['String']>
   id: Scalars['ID']
+  isProvider?: Scalars['Boolean']
   name: Scalars['String']
   rootElement?: InputMaybe<PageRootElementFieldInput>
   slug: Scalars['String']
@@ -13427,6 +13429,7 @@ export type PageInfo = {
 export type PageOnCreateInput = {
   getServerSideProps?: InputMaybe<Scalars['String']>
   id: Scalars['ID']
+  isProvider?: Scalars['Boolean']
   name: Scalars['String']
   slug: Scalars['String']
 }
@@ -13696,6 +13699,7 @@ export type PageRootElementUpdateFieldInput = {
 export type PageSort = {
   getServerSideProps?: InputMaybe<SortDirection>
   id?: InputMaybe<SortDirection>
+  isProvider?: InputMaybe<SortDirection>
   name?: InputMaybe<SortDirection>
   slug?: InputMaybe<SortDirection>
 }
@@ -13950,6 +13954,7 @@ export type PageUpdateInput = {
   app?: InputMaybe<PageAppUpdateFieldInput>
   getServerSideProps?: InputMaybe<Scalars['String']>
   id?: InputMaybe<Scalars['ID']>
+  isProvider?: InputMaybe<Scalars['Boolean']>
   name?: InputMaybe<Scalars['String']>
   rootElement?: InputMaybe<PageRootElementUpdateFieldInput>
   slug?: InputMaybe<Scalars['String']>
@@ -13983,6 +13988,8 @@ export type PageWhere = {
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_STARTS_WITH?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
+  isProvider?: InputMaybe<Scalars['Boolean']>
+  isProvider_NOT?: InputMaybe<Scalars['Boolean']>
   name?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -12352,6 +12352,7 @@ type Page {
   ): PageAppConnection!
   getServerSideProps: String
   id: ID!
+  isProvider: Boolean!
   name: String!
   rootElement(
     directed: Boolean = true
@@ -12540,6 +12541,7 @@ input PageCreateInput {
   app: PageAppFieldInput
   getServerSideProps: String
   id: ID!
+  isProvider: Boolean! = false
   name: String!
   rootElement: PageRootElementFieldInput
   slug: String!
@@ -12590,6 +12592,7 @@ type PageInfo {
 input PageOnCreateInput {
   getServerSideProps: String
   id: ID!
+  isProvider: Boolean! = false
   name: String!
   slug: String!
 }
@@ -12862,6 +12865,7 @@ Fields to sort Pages by. The order in which sorts are applied is not guaranteed 
 input PageSort {
   getServerSideProps: SortDirection
   id: SortDirection
+  isProvider: SortDirection
   name: SortDirection
   slug: SortDirection
 }
@@ -13104,6 +13108,7 @@ input PageUpdateInput {
   app: PageAppUpdateFieldInput
   getServerSideProps: String
   id: ID
+  isProvider: Boolean
   name: String
   rootElement: PageRootElementUpdateFieldInput
   slug: String
@@ -13137,6 +13142,8 @@ input PageWhere {
   id_NOT_IN: [ID!]
   id_NOT_STARTS_WITH: ID
   id_STARTS_WITH: ID
+  isProvider: Boolean
+  isProvider_NOT: Boolean
   name: String
   name_CONTAINS: String
   name_ENDS_WITH: String


### PR DESCRIPTION
## Description (Optional)

This #1785 task requires at least these steps to be done:
1. ✅ Create `_app` page automatically when app is created in the builder
2. ✅ Add `isProvider` property to the page schema so that we can programmatically distinguish it from others
3. ✅ Update autogenerated backend endpoints to return new "isProvider" field to client
4. ✅ Disable the ability to rename or delete this page
5. ✅ Pass the page to a renderer so that it is used as a wrapper over all other pages.
    Looks like there are 3 places where it is used: 
        `apps/builder/pages/_sites/user/[user]/[app]/[page]/index.tsx`
        `apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx`
        `apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx`
6. ✅ Probably some refactoring to reduce copy-pasted code (there is big piece of code that looks the same in the files above)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1785 
