### PR TITLE
fix: remove prop of type ReactNode error

### DIFF
--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -406,6 +406,14 @@ export class Renderer
         return propTransformer.transform(value, typeKind)
       }
 
+      /*
+       * We need to return an empty string here, if the prop cannot be transformed, otherwise
+       * the empty object will be passed as React Child, which will throw an error
+       */
+      if (typeKind === ITypeKind.ReactNodeType) {
+        return ''
+      }
+
       return {}
     })
 


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)
Fixes the error thrown after removing a prop of type `ReactNodeType` from element props.

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1977
