### PR TITLE
fix: remove spec pattern from cypress test config

### DIFF
--- a/apps/builder-e2e/cypress.test.config.ts
+++ b/apps/builder-e2e/cypress.test.config.ts
@@ -31,6 +31,5 @@ export default defineConfig({
     ...nxE2EPreset(__filename),
     ...cypressJsonConfig,
     setupNodeEvents,
-    specPattern: '**/e2e/**/component.cy.{js,jsx,ts,tsx}',
   },
 })

--- a/apps/builder-e2e/project.json
+++ b/apps/builder-e2e/project.json
@@ -40,6 +40,7 @@
         },
         "dev": {
           "cypressConfig": "apps/builder-e2e/cypress.test.config.ts",
+          "devServerTarget": "builder-e2e:serve:dev",
           "watch": true,
           "exit": false
         }
@@ -87,11 +88,17 @@
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
-        "lintFilePatterns": ["apps/builder-e2e/**/*.{js,ts}"]
+        "lintFilePatterns": [
+          "apps/builder-e2e/**/*.{js,ts}"
+        ]
       },
-      "outputs": ["{options.outputFile}"]
+      "outputs": [
+        "{options.outputFile}"
+      ]
     }
   },
   "tags": [],
-  "implicitDependencies": ["builder"]
+  "implicitDependencies": [
+    "builder"
+  ]
 }

--- a/apps/builder-e2e/project.json
+++ b/apps/builder-e2e/project.json
@@ -66,7 +66,7 @@
         "test": {
           "commands": [
             {
-              "command": "npx wait-on --interval 1000  'http://127.0.0.1:3001' && echo 'READY'"
+              "command": "npx wait-on --interval 1000 --delay 3000 'http://127.0.0.1:3001' && echo 'READY'"
             },
             {
               "command": "nx serve-test builder -c test"
@@ -76,7 +76,7 @@
         "ci": {
           "commands": [
             {
-              "command": "npx wait-on --interval 1000 'http://127.0.0.1:3000' && echo 'READY'"
+              "command": "npx wait-on --interval 1000 --delay 3000 'http://127.0.0.1:3000' && echo 'READY'"
             },
             {
               "command": "nx serve-test builder -c ci"
@@ -88,17 +88,11 @@
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
-        "lintFilePatterns": [
-          "apps/builder-e2e/**/*.{js,ts}"
-        ]
+        "lintFilePatterns": ["apps/builder-e2e/**/*.{js,ts}"]
       },
-      "outputs": [
-        "{options.outputFile}"
-      ]
+      "outputs": ["{options.outputFile}"]
     }
   },
   "tags": [],
-  "implicitDependencies": [
-    "builder"
-  ]
+  "implicitDependencies": ["builder"]
 }


### PR DESCRIPTION
## Description (Optional)
- Show all existing tests instead of a single test in cypress development environment
- Add run server in cypress dev configuration



