### PR TITLE
1988 props panel scroll issue

### DIFF
--- a/apps/builder-e2e/src/e2e/providersPage.cy.ts
+++ b/apps/builder-e2e/src/e2e/providersPage.cy.ts
@@ -117,6 +117,9 @@ describe('_app page', () => {
     cy.get(`[aria-label="setting"]`).click()
     cy.findByLabelText(/Component Disabled/).click()
 
+    // After atom props are changed - need to wait for the corresponding API call
+    // which is sent to the server in order to save this change to the database.
+    // Otherwise, there is a risk that `cy.go('back')` will prevent the request from being sent
     cy.waitForApiCalls()
 
     cy.go('back')

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -197,11 +197,6 @@ PageBuilder.Layout = observer((page) => {
               resourceMenuItem,
             ]}
             secondaryItems={adminMenuItems}
-            // activeBuilderTab={builderService.activeBuilderTab}
-            // key={pageBuilderRenderer?.pageTree?.current.root?.id}
-            // setActiveBuilderTab={builderService.setActiveBuilderTab.bind(
-            //   builderService,
-            // )}
           />
         )}
         contentStyles={{ paddingTop: '0rem' }}

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
@@ -40,15 +40,6 @@ import { PropsInspectorTab } from '../PropsInspectorTab'
 import { TabContainer } from './ConfigPane-InspectorTabContainerStyle'
 import { TAB_NAMES } from './data'
 
-const FormsGrid = ({ children }: React.PropsWithChildren<unknown>) => (
-  <div
-    css={tw`grid grid-cols-2 grid-rows-2 gap-4`}
-    style={{ gridTemplateRows: '1fr auto' }}
-  >
-    {children}
-  </div>
-)
-
 export interface MetaPaneBuilderProps {
   elementTree: IElementTree
   renderService: IRenderer
@@ -153,20 +144,17 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
         label: (
           <TooltipIcon icon={<FormatPainterOutlined />} title={TAB_NAMES.CSS} />
         ),
-        children: (
-          <>
-            {isElement(selectedNode) && selectedNode.atom ? (
-              <ElementCssEditor
-                element={selectedNode}
-                elementService={elementService}
-                key={selectedNode.id}
-                trackPromises={trackPromises}
-              />
-            ) : (
-              `Add an atom to this page element to edit its CSS`
-            )}
-          </>
-        ),
+        children:
+          isElement(selectedNode) && selectedNode.atom ? (
+            <ElementCssEditor
+              element={selectedNode}
+              elementService={elementService}
+              key={selectedNode.id}
+              trackPromises={trackPromises}
+            />
+          ) : (
+            `Add an atom to this page element to edit its CSS`
+          ),
       },
       {
         key: TAB_NAMES.PropsInspector,
@@ -176,17 +164,13 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
             title={TAB_NAMES.PropsInspector}
           />
         ),
-        children: (
-          <>
-            {isElement(selectedNode) && (
-              <PropsInspectorTab
-                element={selectedNode}
-                elementService={elementService}
-                key={selectedNode.id}
-                renderer={renderService}
-              />
-            )}
-          </>
+        children: isElement(selectedNode) && (
+          <PropsInspectorTab
+            element={selectedNode}
+            elementService={elementService}
+            key={selectedNode.id}
+            renderer={renderService}
+          />
         ),
       },
       {
@@ -194,21 +178,17 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
         label: (
           <TooltipIcon icon={<SwapOutlined />} title={TAB_NAMES.PropsMap} />
         ),
-        children: (
-          <>
-            {isElement(selectedNode) ? (
-              <PropMapBindingSection
-                element={selectedNode}
-                elementService={elementService}
-                elementTree={elementTree}
-                key={selectedNode.id}
-                providePropCompletion={(searchValue) =>
-                  providePropCompletion(searchValue, selectedNode.id)
-                }
-              />
-            ) : null}
-          </>
-        ),
+        children: isElement(selectedNode) ? (
+          <PropMapBindingSection
+            element={selectedNode}
+            elementService={elementService}
+            elementTree={elementTree}
+            key={selectedNode.id}
+            providePropCompletion={(searchValue) =>
+              providePropCompletion(searchValue, selectedNode.id)
+            }
+          />
+        ) : null,
       },
       {
         key: TAB_NAMES.PropsTransformation,
@@ -218,18 +198,14 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
             title={TAB_NAMES.PropsTransformation}
           />
         ),
-        children: (
-          <>
-            {isElement(selectedNode) ? (
-              <UpdateElementPropTransformationForm
-                element={selectedNode}
-                elementService={elementService}
-                key={selectedNode.id}
-                trackPromises={trackPromises}
-              />
-            ) : null}
-          </>
-        ),
+        children: isElement(selectedNode) ? (
+          <UpdateElementPropTransformationForm
+            element={selectedNode}
+            elementService={elementService}
+            key={selectedNode.id}
+            trackPromises={trackPromises}
+          />
+        ) : null,
       },
     ]
 

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
@@ -64,7 +64,6 @@ export const ConfigPane = observer<MetaPaneProps>(
           <Tabs.TabPane
             destroyInactiveTabPane
             key="inspector"
-            // style={{ overflow: 'auto', maxHeight: '100%' }}
             tab={
               <div>
                 <EditOutlined />
@@ -129,7 +128,6 @@ export const ConfigPane = observer<MetaPaneProps>(
           <Tabs.TabPane
             destroyInactiveTabPane
             key="component"
-            // style={{ overflow: 'auto', maxHeight: '100%' }}
             tab={
               <div>
                 <CodeSandboxOutlined />

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
@@ -99,7 +99,7 @@ export const ConfigPane = observer<MetaPaneProps>(
                           trackPromises={trackPromises}
                         />
                         <DeleteElementButton
-                          css={tw`mt-3`}
+                          css={tw`my-3`}
                           disabled={node.isRoot}
                           element={node}
                           elementService={elementService}

--- a/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
+++ b/libs/frontend/domain/element/src/use-cases/element/update-element-props/UpdateElementPropsForm.tsx
@@ -17,6 +17,7 @@ import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
 import React, { useRef } from 'react'
 import { useAsync } from 'react-use'
+import tw from 'twin.macro'
 
 export interface UpdateElementPropsFormProps {
   typeService: ITypeService
@@ -70,7 +71,7 @@ export const UpdateElementPropsForm = observer<UpdateElementPropsFormProps>(
     return (
       <Spinner isLoading={loading}>
         {interfaceType && (
-          <Row gutter={[0, 16]}>
+          <Row css={tw`mb-5`} gutter={[0, 16]}>
             <Col span={24}>
               <PropsForm
                 autosave

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate-ConfigPane.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate-ConfigPane.tsx
@@ -18,15 +18,13 @@ export const DashboardTemplateConfigPane = ({
 }: ConfigPaneProps) => {
   return (
     <motion.div
-      css={tw`fixed top-0 right-0 bottom-0 h-full bg-white z-50 flex flex-row`}
+      css={tw`fixed top-0 right-0 bottom-0 bg-white z-50 flex flex-row`}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...resizable.containerProps}
       style={{
         ...resizable.containerProps.style,
-        // marginLeft: mainPaneMarginLeft,
-        // paddingLeft: sidebarNavMarginLeft,
-        // Add 8 for header padding
         top: `${defaultHeaderHeight}px`,
+        height: `calc(100% - ${defaultHeaderHeight}px)`,
       }}
     >
       <motion.div

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate-ConfigPane.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate-ConfigPane.tsx
@@ -5,11 +5,8 @@ import { UseResizable } from '../../components'
 import { defaultHeaderHeight } from './constants'
 
 export interface ConfigPaneProps {
-  // hasSidebarNavigation: boolean
   ConfigPane: ComponentType
   resizable: UseResizable
-  // hasConfigPane: boolean
-  // mainPaneWidth: MotionValue<number>
 }
 
 export const DashboardTemplateConfigPane = ({

--- a/libs/frontend/view/templates/Dashboard/DashboardTemplate.tsx
+++ b/libs/frontend/view/templates/Dashboard/DashboardTemplate.tsx
@@ -186,9 +186,6 @@ export const DashboardTemplate = observer(
               {ConfigPane && (
                 <DashboardTemplateConfigPane
                   ConfigPane={ConfigPane}
-                  // hasConfigPane={Boolean(ExplorerPane)}
-                  // hasSidebarNavigation={Boolean(SidebarNavigation)}
-                  // mainPaneWidth={mainPaneResizable.width}
                   resizable={metaPaneResizable}
                 />
               )}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

This PR fixes the scrolling issue of the props panel. Some portion of the content was rendered out of the screen because the panel had 100% height but was shifted to 48px from the top (because of the header). Also, padding is added for the last child in the panel so it is displayed better.
Some minor changes to the related codebase were made: removed unused functions, commented code, and fixed some warnings from vscode.

Before             |  After
:-------------------------:|:-------------------------:
<img width="359" alt="Снимок экрана 2022-11-15 в 13 20 17" src="https://user-images.githubusercontent.com/74900868/201907271-f54944bb-0e28-4c50-a51c-e79175cf32df.png">  |  <img width="359" alt="Снимок экрана 2022-11-15 в 13 13 40" src="https://user-images.githubusercontent.com/74900868/201906944-d26f05f2-61f1-4305-af3d-4f85241e01ad.png">
<img width="358" alt="Снимок экрана 2022-11-15 в 13 21 08" src="https://user-images.githubusercontent.com/74900868/201907437-6c888d35-272c-401e-8a7c-d0ae545fb366.png"> | <img width="358" alt="Снимок экрана 2022-11-15 в 13 13 53" src="https://user-images.githubusercontent.com/74900868/201907087-fa186787-1eaa-4a53-9865-00f04316ca07.png">



<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1988
