### PR TITLE
fix: select component issue when inside scrollable container

### DIFF
--- a/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-action/SelectAction.tsx
@@ -43,6 +43,7 @@ export const SelectAction = ({ name, label, error }: SelectActionProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       label={label}
       loading={isLoading}
       name={name}

--- a/libs/frontend/domain/type/src/interface-form/fields/select-app/SelectApp.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-app/SelectApp.tsx
@@ -22,6 +22,7 @@ export const SelectApp = ({ name, error }: UniformSelectFieldProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       loading={isLoading}
       name={name}
       optionFilterProp="label"

--- a/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-atom/SelectAtom.tsx
@@ -65,6 +65,7 @@ export const SelectAtom = ({ label, name, error, parent }: SelectAtomProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       label={label}
       loading={isLoading}
       name={name}

--- a/libs/frontend/domain/type/src/interface-form/fields/select-component/SelectComponent.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-component/SelectComponent.tsx
@@ -36,6 +36,7 @@ export const SelectComponent = ({ name, error }: SelectComponentProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       loading={isLoading}
       name={name}
       optionFilterProp="label"

--- a/libs/frontend/domain/type/src/interface-form/fields/select-element/SelectElement.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-element/SelectElement.tsx
@@ -75,6 +75,7 @@ export const SelectElement = ({
 
   return (
     <SelectField
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       {...(props as SelectFieldProps)}
       disabled={
         disableWhenOneOpt && (elements.length === 1 || !elements.length)

--- a/libs/frontend/domain/type/src/interface-form/fields/select-page/SelectPage.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-page/SelectPage.tsx
@@ -36,6 +36,7 @@ export const SelectPage = ({ name, error }: SelectPageProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       label="Page"
       loading={isLoading}
       name={name}

--- a/libs/frontend/domain/type/src/interface-form/fields/select-resource/SelectResource.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-resource/SelectResource.tsx
@@ -17,6 +17,7 @@ export const SelectResource = observer<SelectResourcesProps>(
 
     return (
       <SelectField
+        getPopupContainer={(triggerNode) => triggerNode.parentElement}
         name={name}
         optionFilterProp="label"
         options={options}

--- a/libs/frontend/domain/type/src/interface-form/fields/select-store/SelectStore.tsx
+++ b/libs/frontend/domain/type/src/interface-form/fields/select-store/SelectStore.tsx
@@ -24,6 +24,7 @@ export const SelectStore = ({ name, error, where }: SelectStoreProps) => {
   return (
     <SelectField
       error={error || queryError}
+      getPopupContainer={(triggerNode) => triggerNode.parentElement}
       loading={isLoading}
       name={name}
       optionFilterProp="label"

--- a/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
+++ b/libs/frontend/domain/type/src/interface-form/type-schema.factory.ts
@@ -237,6 +237,7 @@ export class TypeSchemaFactory {
       })),
       showSearch: true,
       optionFilterProp: 'label',
+      getPopupContainer: (triggerNode: Element) => triggerNode.parentElement,
       ...extra?.uniforms,
     }
 


### PR DESCRIPTION
## Description

There is an issue with `antd` Select component when it is rendered inside a scrollable container.
In official documentation for this component (https://ant.design/components/select/) as a valid solution suggested to customize `getPopupContainer` prop which defines where the dropdown menu will be rendered (default is body).
As a fix - the dropdown menu should render next to the select component in DOM.

This fix was applied to all places where there was a chance to get this issue.

Note: It is possible to define `getPopupContainer` method on `ConfigProvider` node inside of `_app.tsx`, but this does not work for us. Most of the Select components are rendered in forms using `teraform-antd`. This package uses the Select component from `antd/lib/select` location, and this component does not take into account settings from `ConfigProvider`. Only Select components imported from root `antd` inherit settings defined on `ConfigProvider`. That is why the fix was duplicated to all possible places instead of defining it once on a `ConfigProvider`


Fixes #1983
