### PR TITLE
tweak log behaviors in e2e, next API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@
 # Next
 #
 NEXT_PUBLIC_BUILDER_HOST=127.0.0.1:3000
+NEXT_API_ENABLE_LOGGING=false
 
 #
 # Auth0 - Next - those are required by nextjs-auth0 - don't change their names

--- a/.env.test.example
+++ b/.env.test.example
@@ -7,6 +7,7 @@
 # Next
 #
 NEXT_PUBLIC_BUILDER_HOST='127.0.0.1:3001'
+NEXT_API_ENABLE_LOGGING=false
 
 #
 # Auth0 - Next - those are required by nextjs-auth0 - don't change their names

--- a/apps/builder-e2e/cypress.ci.config.ts
+++ b/apps/builder-e2e/cypress.ci.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
     ...nxE2EPreset(__filename),
     ...cypressJsonConfig,
     setupNodeEvents,
-    // specPattern: '**/e2e/**/component.cy.{js,jsx,ts,tsx}',
+    env: {
+      CYPRESS_ENABLE_LOGGING: false,
+    },
   },
 })

--- a/apps/builder-e2e/cypress.test.config.ts
+++ b/apps/builder-e2e/cypress.test.config.ts
@@ -31,5 +31,8 @@ export default defineConfig({
     ...nxE2EPreset(__filename),
     ...cypressJsonConfig,
     setupNodeEvents,
+    env: {
+      CYPRESS_ENABLE_LOGGING: false,
+    },
   },
 })

--- a/apps/builder-e2e/src/support/e2e.ts
+++ b/apps/builder-e2e/src/support/e2e.ts
@@ -20,6 +20,7 @@ import 'cypress-jest-adapter'
 import './commands'
 import './antd/register'
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+import { Env } from './env'
 
 Cypress.on('uncaught:exception', (err) => {
   const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
@@ -43,4 +44,6 @@ beforeEach(() => {
   // cy.preserveAuth0CookiesOnce()
 })
 
-installLogsCollector()
+if (Env().e2e.enableLogging) {
+  installLogsCollector()
+}

--- a/apps/builder-e2e/src/support/env.ts
+++ b/apps/builder-e2e/src/support/env.ts
@@ -1,0 +1,11 @@
+interface Env {
+  e2e: {
+    enableLogging?: boolean
+  }
+}
+
+export const Env = (): Env => ({
+  e2e: {
+    enableLogging: Cypress.env('CYPRESS_ENABLE_LOGGING'),
+  },
+})

--- a/libs/frontend/domain/user/src/uses-cases/upsert-user/upsert-user.ts
+++ b/libs/frontend/domain/user/src/uses-cases/upsert-user/upsert-user.ts
@@ -19,12 +19,8 @@ export const upsertUser = async (
     },
   })
 
-  console.log('roles', user[JWT_CLAIMS].roles)
-
   if (existing) {
     // console.debug(`User with email ${user.email} already exists!`)
-
-    console.log('found')
 
     const { users } = await User.update({
       where: {
@@ -39,24 +35,6 @@ export const upsertUser = async (
     })
   } else {
     try {
-      console.log(
-        'create new',
-        JSON.stringify(
-          {
-            input: [
-              {
-                auth0Id: user.sub,
-                email: user.email,
-                username: user.email,
-                roles: user[JWT_CLAIMS].roles,
-              },
-            ],
-          },
-          null,
-          2,
-        ),
-      )
-
       const { users } = await User.create({
         input: [
           {
@@ -67,8 +45,6 @@ export const upsertUser = async (
           },
         ],
       })
-
-      console.log('creating new users', users)
 
       return users[0]
 

--- a/libs/shared/adapter/logging/src/winston-driver.ts
+++ b/libs/shared/adapter/logging/src/winston-driver.ts
@@ -31,6 +31,10 @@ export const logger = createLogger({
     // - Write all logs with importance level of `error` or less to `error.log`
     // - Write all logs with importance level of `info` or less to `combined.log`
     //
+    new transports.Console({
+      level: 'info',
+    }),
+
     new transports.File({
       filename: 'logs/info.log',
       level: 'info',

--- a/libs/shared/env/src/env.ts
+++ b/libs/shared/env/src/env.ts
@@ -24,6 +24,9 @@ interface Env {
     // cypress_password?: string
     base_url: string
   }
+  next: {
+    enableAPILogging?: boolean
+  }
 }
 
 export const Env = (): Env => ({
@@ -50,5 +53,8 @@ export const Env = (): Env => ({
       isVercelPreview
         ? `https://${env.get('VERCEL_URL').required().asString()}`
         : `http://${env.get('NEXT_PUBLIC_BUILDER_HOST').required().asString()}`,
+  },
+  next: {
+    enableAPILogging: env.get('NEXT_API_ENABLE_LOGGING').asBool(),
   },
 })


### PR DESCRIPTION
## Description
- Set `CYPRESS_ENABLE_LOGGING` in cypress config to enable logging in e2e test
- Set `NEXT_API_ENABLE_LOGGING` in `.env` to enable logging next API request/response. For enabling in e2e test, set the env in command section when starting server
`apps/builder-e2e/project.json`
```js
        "test": {
          "commands": [
            {
              "command": "npx wait-on --interval 1000 --delay 3000 'http://127.0.0.1:3001' && echo 'READY'"
            },
            {
              "command": "NEXT_API_ENABLE_LOGGING=true nx serve-test builder -c test"
            }
          ]
        },
```
- Use existing logs, remove unused logs


<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2009 
