### PR TITLE
test(apps-builder-e2e): stabilize tags.cy e2e test (#2015)

### DIFF
--- a/apps/builder-e2e/src/data/tag.ts
+++ b/apps/builder-e2e/src/data/tag.ts
@@ -1,25 +1,25 @@
 export const createData = {
   // Parent
-  tag_0: 'Create-Tag-0',
+  tag_0: 'Create-Tag-0.',
   // Child
-  tag_0_0: 'Create-Tag-0-0',
+  tag_0_0: 'Create-Tag-0-0.',
 }
 
 export const updateData = {
-  tag_0: 'Update-Tag-0',
-  updated_tag_0: 'Updated-Tag-0',
+  tag_0: 'Update-Tag-0.',
+  updated_tag_0: 'Updated-Tag-0.',
 }
 
 export const deleteData = {
   tree: {
-    tag_0: 'Delete-Tree-Tag-0',
-    tag_0_0: 'Delete-Tree-Tag-0-0',
-    tag_1: 'Delete-Tree-Tag-1',
-    tag_1_0: 'Delete-Tree-Tag-1-0',
+    tag_0: 'Delete-Tree-Tag-0.',
+    tag_0_0: 'Delete-Tree-Tag-0-0.',
+    tag_1: 'Delete-Tree-Tag-1.',
+    tag_1_0: 'Delete-Tree-Tag-1-0.',
   },
   table: {
-    tag_0_0: 'Delete-Tag-0-0',
-    tag_0: 'Delete-Tag-0',
-    tag_0_1: 'Delete-Tag-0-1',
+    tag_0_0: 'Delete-Tag-0-0.',
+    tag_0: 'Delete-Tag-0.',
+    tag_0_1: 'Delete-Tag-0-1.',
   },
 }


### PR DESCRIPTION


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

Rework names of the tags that are used in the tags.cy.ts spec. The failing test was trying to delete the tag with the name "Delete-Tag-0", but tags with the names "Delete-Tag-0-0" and "Delete-Tag-0-1" also matched the "contains" condition. In the "before" hook, depending on what tag is created first - determined final tags order in the grid. And sometimes the wrong tag gets deleted ("Delete-Tag-0-1" instead of "Delete-tag-0") and the assertion fails. With new names - there is no way some different tag will match the selector

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2015
