### PR TITLE
fix(apps-cli): fix key/value seed data for enums (Preparation step for the task #1553)

### DIFF
--- a/apps/cli/src/use-cases/seed/types/enum-type-map.ts
+++ b/apps/cli/src/use-cases/seed/types/enum-type-map.ts
@@ -46,8 +46,8 @@ export const getEnumTypeForApi: FieldTypeRef = async ({
               create: values.map((value) => ({
                 node: {
                   id: v4(),
-                  key: value,
-                  value: pascalCaseToWords(value),
+                  key: pascalCaseToWords(value),
+                  value,
                 },
               })),
             },


### PR DESCRIPTION

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
When on the Props form some value is selected from the dropdown (EnumType) - pascal case value is used and passed as a parameter to the component. Such values are invalid and they are ignored by components. So most of the Enum properties do not work for many of the atoms. For example there is "shape" dropdown for Button atom exists. The corresponding dropdown had values equal to "Square" and "Circle", but this are invalid values, "square" and "circle" must be used instead. So this commit swaps key and value, and now all dropdowns will render on UI user-friendly Pascal case name and will use lower-case strings as values.

Before            |  After
:-------------------------:|:-------------------------:
<img width="354" alt="Screenshot 2022-11-26 at 22 22 59" src="https://user-images.githubusercontent.com/74900868/204107709-3420a1c1-f3c7-4017-a92d-3786597fbd45.png">|<img width="357" alt="Screenshot 2022-11-26 at 22 10 34" src="https://user-images.githubusercontent.com/74900868/204107256-527d0c83-25d2-4b21-9213-41013ef35ea1.png">
<img width="685" alt="Screenshot 2022-11-26 at 22 24 25" src="https://user-images.githubusercontent.com/74900868/204107803-bbb37f53-5ab4-4a8a-b669-0a33506d28ab.png">|<img width="653" alt="Screenshot 2022-11-26 at 22 12 36" src="https://user-images.githubusercontent.com/74900868/204107312-eb08ab68-2e93-4c34-a5e6-02e9e626804e.png">


<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
