### PR TITLE
fix atom table filter (server side filtering)

### DIFF
--- a/apps/builder/pages/atoms/index.tsx
+++ b/apps/builder/pages/atoms/index.tsx
@@ -1,7 +1,6 @@
 import { CodelabPage } from '@codelab/frontend/abstract/types'
 import {
   AtomLibrary,
-  AtomRecord,
   CreateAtomButton,
   CreateAtomModal,
   DeleteAtomsModal,
@@ -28,8 +27,6 @@ import {
   DashboardTemplateProps,
   SidebarNavigation,
 } from '@codelab/frontend/view/templates'
-import { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
-import { Maybe } from '@codelab/shared/abstract/types'
 import { auth0Instance } from '@codelab/shared/adapter/auth0'
 import { PageHeader } from 'antd'
 import { observer } from 'mobx-react-lite'
@@ -44,7 +41,7 @@ const AtomsPage: CodelabPage<DashboardTemplateProps> = observer(() => {
   const antdAtomsKeys = useMemo(() => Object.keys(antdAtoms), [])
   const clAtomsKeys = useMemo(() => Object.keys(codelabAtoms), [])
 
-  const getLibrary = useCallback(
+  const getAtomLibrary = useCallback(
     (atomType: string): AtomLibrary => {
       return htmlAtomsKeys.includes(atomType)
         ? { name: 'HTML', color: 'orange' }
@@ -58,30 +55,6 @@ const AtomsPage: CodelabPage<DashboardTemplateProps> = observer(() => {
     },
     [htmlAtomsKeys, antdAtomsKeys, muiAtomsKeys, clAtomsKeys],
   )
-
-  const fetchAtomsData = async (
-    where: Maybe<AtomWhere>,
-    options: Maybe<AtomOptions>,
-  ) => {
-    await Promise.all([
-      store.atomService.getAll(where, options),
-      store.tagService.getAll(),
-    ])
-
-    const atomsData: Array<AtomRecord> = store.atomService.atomsList.map(
-      (atom) => ({
-        id: atom.id,
-        type: atom.type,
-        apiId: atom.api.id,
-        name: atom.name,
-        tags: atom.tags.map((tag) => tag.current),
-        library: getLibrary(atom.type),
-        allowedChildren: atom.allowedChildren,
-      }),
-    )
-
-    return atomsData
-  }
 
   return (
     <>
@@ -102,7 +75,7 @@ const AtomsPage: CodelabPage<DashboardTemplateProps> = observer(() => {
       <ContentSection>
         <GetAtomsTable
           atomService={store.atomService}
-          fetchAtomsData={fetchAtomsData}
+          getAtomLibrary={getAtomLibrary}
         />
       </ContentSection>
     </>

--- a/libs/backend/abstract/codegen/src/ogm-types.gen.ts
+++ b/libs/backend/abstract/codegen/src/ogm-types.gen.ts
@@ -7086,6 +7086,7 @@ export type ActionTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -7096,6 +7097,7 @@ export type ActionTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -7763,6 +7765,7 @@ export type ApiActionWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -7773,6 +7776,7 @@ export type ApiActionWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -8431,6 +8435,7 @@ export type AppTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -8441,6 +8446,7 @@ export type AppTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -8479,6 +8485,7 @@ export type AppWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -8489,6 +8496,7 @@ export type AppWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -8499,6 +8507,7 @@ export type AppWhere = {
   slug_NOT?: InputMaybe<Scalars['String']>
   slug_IN?: InputMaybe<Array<Scalars['String']>>
   slug_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  slug_MATCHES?: InputMaybe<Scalars['String']>
   slug_CONTAINS?: InputMaybe<Scalars['String']>
   slug_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   slug_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -9569,6 +9578,7 @@ export type ArrayTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -9579,6 +9589,7 @@ export type ArrayTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10004,6 +10015,7 @@ export type AtomWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -10014,6 +10026,7 @@ export type AtomWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10024,6 +10037,7 @@ export type AtomWhere = {
   icon_NOT?: InputMaybe<Scalars['String']>
   icon_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   icon_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  icon_MATCHES?: InputMaybe<Scalars['String']>
   icon_CONTAINS?: InputMaybe<Scalars['String']>
   icon_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   icon_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10233,6 +10247,7 @@ export type BaseTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -10243,6 +10258,7 @@ export type BaseTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10373,6 +10389,7 @@ export type CodeActionWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -10383,6 +10400,7 @@ export type CodeActionWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10393,6 +10411,7 @@ export type CodeActionWhere = {
   code_NOT?: InputMaybe<Scalars['String']>
   code_IN?: InputMaybe<Array<Scalars['String']>>
   code_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  code_MATCHES?: InputMaybe<Scalars['String']>
   code_CONTAINS?: InputMaybe<Scalars['String']>
   code_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   code_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -10562,6 +10581,7 @@ export type CodeMirrorTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -10572,6 +10592,7 @@ export type CodeMirrorTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -11085,6 +11106,7 @@ export type ComponentWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -11095,6 +11117,7 @@ export type ComponentWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -11155,6 +11178,7 @@ export type CreateInfoWhere = {
   bookmark_NOT?: InputMaybe<Scalars['String']>
   bookmark_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   bookmark_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  bookmark_MATCHES?: InputMaybe<Scalars['String']>
   bookmark_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -11216,6 +11240,7 @@ export type DeleteInfoWhere = {
   bookmark_NOT?: InputMaybe<Scalars['String']>
   bookmark_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   bookmark_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  bookmark_MATCHES?: InputMaybe<Scalars['String']>
   bookmark_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -11425,6 +11450,7 @@ export type DomainWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -11435,6 +11461,7 @@ export type DomainWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13414,6 +13441,7 @@ export type ElementTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -13424,6 +13452,7 @@ export type ElementTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13479,6 +13508,7 @@ export type ElementWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -13489,6 +13519,7 @@ export type ElementWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   name_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13499,6 +13530,7 @@ export type ElementWhere = {
   customCss_NOT?: InputMaybe<Scalars['String']>
   customCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   customCss_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  customCss_MATCHES?: InputMaybe<Scalars['String']>
   customCss_CONTAINS?: InputMaybe<Scalars['String']>
   customCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   customCss_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13509,6 +13541,7 @@ export type ElementWhere = {
   guiCss_NOT?: InputMaybe<Scalars['String']>
   guiCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   guiCss_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  guiCss_MATCHES?: InputMaybe<Scalars['String']>
   guiCss_CONTAINS?: InputMaybe<Scalars['String']>
   guiCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   guiCss_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13519,6 +13552,7 @@ export type ElementWhere = {
   propTransformationJs_NOT?: InputMaybe<Scalars['String']>
   propTransformationJs_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   propTransformationJs_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  propTransformationJs_MATCHES?: InputMaybe<Scalars['String']>
   propTransformationJs_CONTAINS?: InputMaybe<Scalars['String']>
   propTransformationJs_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   propTransformationJs_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13529,6 +13563,7 @@ export type ElementWhere = {
   renderForEachPropKey_NOT?: InputMaybe<Scalars['String']>
   renderForEachPropKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   renderForEachPropKey_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  renderForEachPropKey_MATCHES?: InputMaybe<Scalars['String']>
   renderForEachPropKey_CONTAINS?: InputMaybe<Scalars['String']>
   renderForEachPropKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   renderForEachPropKey_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13539,6 +13574,7 @@ export type ElementWhere = {
   renderIfPropKey_NOT?: InputMaybe<Scalars['String']>
   renderIfPropKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   renderIfPropKey_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  renderIfPropKey_MATCHES?: InputMaybe<Scalars['String']>
   renderIfPropKey_CONTAINS?: InputMaybe<Scalars['String']>
   renderIfPropKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   renderIfPropKey_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13549,6 +13585,7 @@ export type ElementWhere = {
   preRenderActionId_NOT?: InputMaybe<Scalars['String']>
   preRenderActionId_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   preRenderActionId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  preRenderActionId_MATCHES?: InputMaybe<Scalars['String']>
   preRenderActionId_CONTAINS?: InputMaybe<Scalars['String']>
   preRenderActionId_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   preRenderActionId_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -13559,6 +13596,7 @@ export type ElementWhere = {
   postRenderActionId_NOT?: InputMaybe<Scalars['String']>
   postRenderActionId_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   postRenderActionId_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  postRenderActionId_MATCHES?: InputMaybe<Scalars['String']>
   postRenderActionId_CONTAINS?: InputMaybe<Scalars['String']>
   postRenderActionId_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   postRenderActionId_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14062,6 +14100,7 @@ export type EnumTypeValueWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -14072,6 +14111,7 @@ export type EnumTypeValueWhere = {
   key_NOT?: InputMaybe<Scalars['String']>
   key_IN?: InputMaybe<Array<Scalars['String']>>
   key_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  key_MATCHES?: InputMaybe<Scalars['String']>
   key_CONTAINS?: InputMaybe<Scalars['String']>
   key_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   key_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14082,6 +14122,7 @@ export type EnumTypeValueWhere = {
   value_NOT?: InputMaybe<Scalars['String']>
   value_IN?: InputMaybe<Array<Scalars['String']>>
   value_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  value_MATCHES?: InputMaybe<Scalars['String']>
   value_CONTAINS?: InputMaybe<Scalars['String']>
   value_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   value_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14102,6 +14143,7 @@ export type EnumTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -14112,6 +14154,7 @@ export type EnumTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14368,6 +14411,7 @@ export type FieldWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -14378,6 +14422,7 @@ export type FieldWhere = {
   key_NOT?: InputMaybe<Scalars['String']>
   key_IN?: InputMaybe<Array<Scalars['String']>>
   key_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  key_MATCHES?: InputMaybe<Scalars['String']>
   key_CONTAINS?: InputMaybe<Scalars['String']>
   key_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   key_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14388,6 +14433,7 @@ export type FieldWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   name_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14398,6 +14444,7 @@ export type FieldWhere = {
   description_NOT?: InputMaybe<Scalars['String']>
   description_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   description_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  description_MATCHES?: InputMaybe<Scalars['String']>
   description_CONTAINS?: InputMaybe<Scalars['String']>
   description_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   description_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14408,6 +14455,7 @@ export type FieldWhere = {
   validationRules_NOT?: InputMaybe<Scalars['String']>
   validationRules_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   validationRules_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationRules_MATCHES?: InputMaybe<Scalars['String']>
   validationRules_CONTAINS?: InputMaybe<Scalars['String']>
   validationRules_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   validationRules_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14418,6 +14466,7 @@ export type FieldWhere = {
   defaultValues_NOT?: InputMaybe<Scalars['String']>
   defaultValues_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   defaultValues_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  defaultValues_MATCHES?: InputMaybe<Scalars['String']>
   defaultValues_CONTAINS?: InputMaybe<Scalars['String']>
   defaultValues_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   defaultValues_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -14871,6 +14920,7 @@ export type HookWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -15177,6 +15227,7 @@ export type IBaseTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -15187,6 +15238,7 @@ export type IBaseTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -15654,6 +15706,7 @@ export type InterfaceTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -15664,6 +15717,7 @@ export type InterfaceTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -15872,6 +15926,7 @@ export type LambdaTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -15882,6 +15937,7 @@ export type LambdaTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -16467,6 +16523,7 @@ export type PageTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -16477,6 +16534,7 @@ export type PageTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -16515,6 +16573,7 @@ export type PageWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -16525,6 +16584,7 @@ export type PageWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -16535,6 +16595,7 @@ export type PageWhere = {
   slug_NOT?: InputMaybe<Scalars['String']>
   slug_IN?: InputMaybe<Array<Scalars['String']>>
   slug_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  slug_MATCHES?: InputMaybe<Scalars['String']>
   slug_CONTAINS?: InputMaybe<Scalars['String']>
   slug_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   slug_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -16545,6 +16606,7 @@ export type PageWhere = {
   getServerSideProps_NOT?: InputMaybe<Scalars['String']>
   getServerSideProps_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
   getServerSideProps_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  getServerSideProps_MATCHES?: InputMaybe<Scalars['String']>
   getServerSideProps_CONTAINS?: InputMaybe<Scalars['String']>
   getServerSideProps_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   getServerSideProps_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -16719,6 +16781,7 @@ export type PrimitiveTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -16729,6 +16792,7 @@ export type PrimitiveTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -17311,6 +17375,7 @@ export type PropMapBindingWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -17321,6 +17386,7 @@ export type PropMapBindingWhere = {
   sourceKey_NOT?: InputMaybe<Scalars['String']>
   sourceKey_IN?: InputMaybe<Array<Scalars['String']>>
   sourceKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  sourceKey_MATCHES?: InputMaybe<Scalars['String']>
   sourceKey_CONTAINS?: InputMaybe<Scalars['String']>
   sourceKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   sourceKey_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -17331,6 +17397,7 @@ export type PropMapBindingWhere = {
   targetKey_NOT?: InputMaybe<Scalars['String']>
   targetKey_IN?: InputMaybe<Array<Scalars['String']>>
   targetKey_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  targetKey_MATCHES?: InputMaybe<Scalars['String']>
   targetKey_CONTAINS?: InputMaybe<Scalars['String']>
   targetKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   targetKey_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -17381,6 +17448,7 @@ export type PropWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -17391,6 +17459,7 @@ export type PropWhere = {
   data_NOT?: InputMaybe<Scalars['String']>
   data_IN?: InputMaybe<Array<Scalars['String']>>
   data_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  data_MATCHES?: InputMaybe<Scalars['String']>
   data_CONTAINS?: InputMaybe<Scalars['String']>
   data_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   data_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -17553,6 +17622,7 @@ export type ReactNodeTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -17563,6 +17633,7 @@ export type ReactNodeTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -17729,6 +17800,7 @@ export type RenderPropsTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -17739,6 +17811,7 @@ export type RenderPropsTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -18032,6 +18105,7 @@ export type ResourceWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -18042,6 +18116,7 @@ export type ResourceWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -18519,6 +18594,7 @@ export type StoreWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -18529,6 +18605,7 @@ export type StoreWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -18968,6 +19045,7 @@ export type TagWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -18978,6 +19056,7 @@ export type TagWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -19047,6 +19126,7 @@ export type TypeReferenceWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -19057,6 +19137,7 @@ export type TypeReferenceWhere = {
   label_NOT?: InputMaybe<Scalars['String']>
   label_IN?: InputMaybe<Array<Scalars['String']>>
   label_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  label_MATCHES?: InputMaybe<Scalars['String']>
   label_CONTAINS?: InputMaybe<Scalars['String']>
   label_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   label_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -20407,6 +20488,7 @@ export type UnionTypeWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -20417,6 +20499,7 @@ export type UnionTypeWhere = {
   name_NOT?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
   name_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -21191,6 +21274,7 @@ export type UserWhere = {
   id_NOT?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
   id_NOT_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_STARTS_WITH?: InputMaybe<Scalars['ID']>
@@ -21201,6 +21285,7 @@ export type UserWhere = {
   auth0Id_NOT?: InputMaybe<Scalars['String']>
   auth0Id_IN?: InputMaybe<Array<Scalars['String']>>
   auth0Id_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  auth0Id_MATCHES?: InputMaybe<Scalars['String']>
   auth0Id_CONTAINS?: InputMaybe<Scalars['String']>
   auth0Id_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   auth0Id_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -21211,6 +21296,7 @@ export type UserWhere = {
   email_NOT?: InputMaybe<Scalars['String']>
   email_IN?: InputMaybe<Array<Scalars['String']>>
   email_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  email_MATCHES?: InputMaybe<Scalars['String']>
   email_CONTAINS?: InputMaybe<Scalars['String']>
   email_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   email_STARTS_WITH?: InputMaybe<Scalars['String']>
@@ -21221,6 +21307,7 @@ export type UserWhere = {
   username_NOT?: InputMaybe<Scalars['String']>
   username_IN?: InputMaybe<Array<Scalars['String']>>
   username_NOT_IN?: InputMaybe<Array<Scalars['String']>>
+  username_MATCHES?: InputMaybe<Scalars['String']>
   username_CONTAINS?: InputMaybe<Scalars['String']>
   username_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   username_STARTS_WITH?: InputMaybe<Scalars['String']>

--- a/libs/backend/application/src/repositories/atom/atom.repo.ts
+++ b/libs/backend/application/src/repositories/atom/atom.repo.ts
@@ -1,42 +1,41 @@
 import {
-  atoms,
   atomSelectionSet,
-  atomsWithLimit,
   Repository,
   tagSelectionSet,
 } from '@codelab/backend/infra/adapter/neo4j'
 import { Atom, GetAtomsQueryVariables } from '@codelab/shared/abstract/codegen'
-import { int, Transaction } from 'neo4j-driver'
+import { Transaction } from 'neo4j-driver'
 
 export const atomRepository = {
   /**
-   * Used for field resolver on atom
+   * Used for field resolver on atom. We customly resolve atoms because
+   * the default resolver returns inconsistent results when offset and
+   * limit options are set while querying nested data (#2037)
    */
   atoms: async (
-    txn: Transaction,
+    _: Transaction,
     params: GetAtomsQueryVariables,
   ): Promise<Array<Atom>> => {
-    const cypher = params.options?.limit !== undefined ? atomsWithLimit : atoms
-    const limit = params.options?.limit ?? 0
-    const offset = params.options?.offset ?? 0
+    const limit = params.options?.limit
+    const offset = params.options?.offset
     const AtomInstance = await Repository.instance.Atom
 
-    /**
-     * We can still use the same query, but we get ID from context instead
-     */
-    const { records: atomsRecords } = await txn.run(cypher, {
-      limit: int(limit),
-      skip: int(offset),
+    const filteredItemIds = await AtomInstance.find({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      where: params.where as any,
+      selectionSet: `{ id }`,
+      options: {
+        limit,
+        offset,
+      },
     })
 
-    const items = await Promise.all(
-      atomsRecords
-        .map(async (record) => {
-          const atom = record.get('atom').properties
-
+    const items = Promise.all(
+      filteredItemIds
+        .map(async (item) => {
           return (
             await AtomInstance.find({
-              where: { id: atom.id },
+              where: { id: item.id },
               selectionSet: atomSelectionSet.replace(
                 /tags {([a-z]|\s)*}/g,
                 `tags ${tagSelectionSet}`,

--- a/libs/backend/infra/adapter/neo4j/src/cypher/atom/atoms.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/atom/atoms.cypher
@@ -1,5 +1,0 @@
-// Retrieves all available atoms
-MATCH(atom:Atom)
-RETURN atom
-
-ORDER by atom.name

--- a/libs/backend/infra/adapter/neo4j/src/cypher/atom/atomsWithLimit.cypher
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/atom/atomsWithLimit.cypher
@@ -1,7 +1,0 @@
-// Retrieves all available atoms with offset(skip) and limit
-MATCH(atom:Atom)
-RETURN atom
-
-ORDER by atom.name
-SKIP $skip
-LIMIT $limit

--- a/libs/backend/infra/adapter/neo4j/src/cypher/atom/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/atom/index.ts
@@ -1,4 +1,0 @@
-import atoms from './atoms.cypher'
-import atomsWithLimit from './atomsWithLimit.cypher'
-
-export { atoms, atomsWithLimit }

--- a/libs/backend/infra/adapter/neo4j/src/cypher/index.ts
+++ b/libs/backend/infra/adapter/neo4j/src/cypher/index.ts
@@ -1,4 +1,3 @@
-export * from './atom'
 export * from './component'
 export * from './element'
 export * from './tag'

--- a/libs/backend/infra/adapter/neo4j/src/infra/ogm.ts
+++ b/libs/backend/infra/adapter/neo4j/src/infra/ogm.ts
@@ -11,6 +11,9 @@ export const getOgm = async () => {
     ogm = new OGM({
       typeDefs,
       driver: getDriver(),
+      config: {
+        enableRegex: true,
+      },
     })
 
     await ogm.init()

--- a/libs/backend/infra/adapter/neo4j/src/schema/schema.ts
+++ b/libs/backend/infra/adapter/neo4j/src/schema/schema.ts
@@ -54,4 +54,7 @@ export const getSchema = (driver: Driver, resolvers: IResolvers) =>
         rolesPath: `${escapeDotPathKeys(JWT_CLAIMS)}.roles`,
       }),
     },
+    config: {
+      enableRegex: true,
+    },
   })

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql
@@ -18,14 +18,11 @@ mutation DeleteAtoms($where: AtomWhere!) {
 }
 
 query GetAtoms($where: AtomWhere, $options: AtomOptions) {
-  atomsAggregate {
+  atomsAggregate(where: $where) {
     count
   }
   atoms(where: $where, options: $options) {
     ...Atom
-  }
-  atomsAggregate {
-    count
   }
 }
 

--- a/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
+++ b/libs/frontend/domain/atom/src/graphql/atom.endpoints.graphql.gen.ts
@@ -67,14 +67,11 @@ export const DeleteAtomsDocument = gql`
 `
 export const GetAtomsDocument = gql`
   query GetAtoms($where: AtomWhere, $options: AtomOptions) {
-    atomsAggregate {
+    atomsAggregate(where: $where) {
       count
     }
     atoms(where: $where, options: $options) {
       ...Atom
-    }
-    atomsAggregate {
-      count
     }
   }
   ${AtomFragmentDoc}

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
@@ -1,25 +1,35 @@
 import { IAtomService } from '@codelab/frontend/abstract/core'
+import { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
+import { Maybe } from '@codelab/shared/abstract/types'
 import { Table } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
+import { useAsync } from 'react-use'
 import { AtomRecord } from './columns'
 import { useAtomTable } from './useAtomTable'
 
 interface GetAtomsTableProps {
   atomService: IAtomService
-  atomsData: Array<AtomRecord>
-  isLoading: boolean
+  fetchAtomsData: (
+    where: Maybe<AtomWhere>,
+    options: Maybe<AtomOptions>,
+  ) => Promise<Array<AtomRecord>>
 }
 
 export const GetAtomsTable = observer<GetAtomsTableProps>(
-  ({ atomService, atomsData, isLoading }) => {
-    const { columns, rowSelection, pagination } = useAtomTable(atomService)
+  ({ atomService, fetchAtomsData }) => {
+    const { columns, rowSelection, pagination, atomWhere, atomOptions } =
+      useAtomTable(atomService)
+
+    const { value: atomsData, loading } = useAsync(async () => {
+      return fetchAtomsData(atomWhere, atomOptions)
+    }, [atomWhere, atomOptions])
 
     return (
       <Table
         columns={columns}
         dataSource={atomsData}
-        loading={isLoading}
+        loading={loading}
         pagination={pagination}
         rowKey={(atom) => atom.id}
         rowSelection={rowSelection}

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -48,7 +48,7 @@ export const useAtomTable = (atomService: IAtomService) => {
     'name',
     (value) => {
       const where = {
-        name_CONTAINS: value,
+        name_MATCHES: `(?i).*${value}.*`,
       }
 
       if (!isEqual(where, atomWhere)) {

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -44,9 +44,9 @@ export const useAtomTable = (atomService: IAtomService) => {
     [],
   )
 
-  const nameColumnSearchProps = useColumnSearchProps<AtomRecord>(
-    'name',
-    (value) => {
+  const nameColumnSearchProps = useColumnSearchProps<AtomRecord>({
+    dataIndex: 'name',
+    onSearch: (value) => {
       const where = {
         name_MATCHES: `(?i).*${value}.*`,
       }
@@ -55,7 +55,7 @@ export const useAtomTable = (atomService: IAtomService) => {
         debouncedSetAtomWhere(where)
       }
     },
-  )
+  })
 
   // const { data } = useGetTagGraphsQuery()
   // const tagTree = useTagTree(data?.tagGraphs)

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -1,13 +1,17 @@
 import { IAtomService } from '@codelab/frontend/abstract/core'
 import { useColumnSearchProps } from '@codelab/frontend/view/components'
 import { headerCellProps } from '@codelab/frontend/view/style'
+import { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
+import { Maybe } from '@codelab/shared/abstract/types'
 import {
   ColumnType,
   TablePaginationConfig,
   TableRowSelection,
 } from 'antd/lib/table/interface'
+import debounce from 'lodash/debounce'
+import isEqual from 'lodash/isEqual'
 import { arraySet } from 'mobx-keystone'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { ActionColumn, LibraryColumn, PropsColumn, TagsColumn } from './columns'
 import { AllowedChildrenColumn } from './columns/AllowedChildrenColumn'
 import { AtomRecord } from './columns/types'
@@ -23,6 +27,36 @@ const onLibraryFilter = (
 }
 
 export const useAtomTable = (atomService: IAtomService) => {
+  const [atomWhere, setAtomWhere] = useState<Maybe<AtomWhere>>(undefined)
+
+  const [atomOptions, setAtomOptions] = useState<AtomOptions>({
+    offset: 0,
+    limit: 25,
+  })
+
+  const debouncedSetAtomWhere = useCallback(
+    debounce((value: Maybe<AtomWhere>) => setAtomWhere(value), 1000),
+    [],
+  )
+
+  const debouncedSetAtomOptions = useCallback(
+    debounce((value: AtomOptions) => setAtomOptions(value), 1000),
+    [],
+  )
+
+  const nameColumnSearchProps = useColumnSearchProps<AtomRecord>(
+    'name',
+    (value) => {
+      const where = {
+        name_CONTAINS: value,
+      }
+
+      if (!isEqual(where, atomWhere)) {
+        debouncedSetAtomWhere(where)
+      }
+    },
+  )
+
   // const { data } = useGetTagGraphsQuery()
   // const tagTree = useTagTree(data?.tagGraphs)
   // const tagTreeData = tagTree.getAntdTrees()
@@ -34,7 +68,7 @@ export const useAtomTable = (atomService: IAtomService) => {
       dataIndex: 'name',
       key: 'name',
       onHeaderCell: headerCellProps,
-      ...useColumnSearchProps<AtomRecord>({ dataIndex: 'name' }),
+      ...nameColumnSearchProps,
     },
     {
       title: 'Library',
@@ -91,12 +125,19 @@ export const useAtomTable = (atomService: IAtomService) => {
     defaultPageSize: 25,
     total: atomService.count,
     onChange: async (page: number, pageSize: number) => {
-      await atomService.getAll(undefined, {
+      const options = {
+        offset: (page - 1) * pageSize,
         limit: pageSize,
-        offset: pageSize * (page - 1),
-      })
+      }
+
+      if (!isEqual(options, atomOptions)) {
+        debouncedSetAtomOptions({
+          offset: (page - 1) * pageSize,
+          limit: pageSize,
+        })
+      }
     },
   }
 
-  return { columns, rowSelection, pagination }
+  return { columns, rowSelection, pagination, atomWhere, atomOptions }
 }

--- a/libs/frontend/view/components/table/useColumnSearchProps.tsx
+++ b/libs/frontend/view/components/table/useColumnSearchProps.tsx
@@ -1,69 +1,50 @@
 import { SearchOutlined } from '@ant-design/icons'
 import { Maybe } from '@codelab/shared/abstract/types'
 import { Button, Input, InputRef, Space, TableColumnProps } from 'antd'
-import type { FilterConfirmProps } from 'antd/es/table/interface'
-import React, { useRef } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-interface ColumnSearchProps<RecordType extends object> {
-  dataIndex: keyof RecordType
-  onSearch?: (searchText: string) => void
-}
-
-export const useColumnSearchProps = <RecordType extends object>({
-  dataIndex,
-  onSearch,
-}: ColumnSearchProps<RecordType>) => {
-  // const [state, setState] = useState({
-  //   searchText: '',
-  //   searchedColumn: '',
-  // })
-
+export const useColumnSearchProps = <RecordType extends object>(
+  dataIndex: keyof RecordType,
+  onSearchTextChange?: (value: string) => void,
+) => {
   const searchInputRef = useRef<null | InputRef>(null)
+  const [searchText, setSearchText] = useState('')
 
-  const handleSearch = (
-    searchText: string,
-    confirm: (params: FilterConfirmProps) => void,
-  ) => {
-    confirm({ closeDropdown: false })
-
-    // setState({
-    //   searchText,
-    //   searchedColumn: dataIndex.toString(),
-    // })
-
-    if (onSearch) {
-      // onSearch(searchText)
-    }
-  }
+  const handleSearch = useCallback(() => {
+    onSearchTextChange?.(searchText)
+  }, [searchText, onSearchTextChange])
 
   const handleReset = (clearFilters: Maybe<() => void>) => {
     if (clearFilters !== undefined) {
       clearFilters()
     }
 
-    // setState({ searchText: '', searchedColumn: '' })
+    setSearchText('')
   }
 
+  useEffect(() => {
+    handleSearch()
+  }, [searchText, onSearchTextChange, handleSearch])
+
   return {
-    filterDropdown: ({
-      setSelectedKeys,
-      selectedKeys,
-      confirm,
-      clearFilters,
-    }) => (
+    filterDropdown: ({ setSelectedKeys, confirm, clearFilters }) => (
       <div style={{ padding: 8 }}>
         <Input
           onChange={(e) => {
             setSelectedKeys(e.target.value ? [e.target.value] : [])
-            handleSearch(e.target.value, confirm)
+            confirm({ closeDropdown: false })
+            setSearchText(e.target.value)
           }}
-          // onPressEnter={(e) => handleSearch(e.target.value, confirm)}
+          onPressEnter={() => {
+            confirm({ closeDropdown: false })
+            handleSearch()
+          }}
           placeholder={`Search ${dataIndex.toString()}`}
           ref={(node) => {
             searchInputRef.current = node
           }}
           style={{ marginBottom: 8, display: 'block' }}
-          value={selectedKeys[0]}
+          value={searchText}
         />
         <Space>
           {/* <Button */}
@@ -76,7 +57,10 @@ export const useColumnSearchProps = <RecordType extends object>({
           {/*  Search */}
           {/* </Button> */}
           <Button
-            onClick={() => handleReset(clearFilters)}
+            onClick={() => {
+              handleReset(clearFilters)
+              confirm({ closeDropdown: true })
+            }}
             size="small"
             style={{ width: 90 }}
           >

--- a/libs/frontend/view/components/table/useColumnSearchProps.tsx
+++ b/libs/frontend/view/components/table/useColumnSearchProps.tsx
@@ -3,16 +3,21 @@ import { Maybe } from '@codelab/shared/abstract/types'
 import { Button, Input, InputRef, Space, TableColumnProps } from 'antd'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-export const useColumnSearchProps = <RecordType extends object>(
-  dataIndex: keyof RecordType,
-  onSearchTextChange?: (value: string) => void,
-) => {
+interface ColumnSearchProps<RecordType extends object> {
+  dataIndex: keyof RecordType
+  onSearch?: (searchText: string) => void
+}
+
+export const useColumnSearchProps = <RecordType extends object>({
+  dataIndex,
+  onSearch,
+}: ColumnSearchProps<RecordType>) => {
   const searchInputRef = useRef<null | InputRef>(null)
   const [searchText, setSearchText] = useState('')
 
   const handleSearch = useCallback(() => {
-    onSearchTextChange?.(searchText)
-  }, [searchText, onSearchTextChange])
+    onSearch?.(searchText)
+  }, [searchText, onSearch])
 
   const handleReset = (clearFilters: Maybe<() => void>) => {
     if (clearFilters !== undefined) {
@@ -24,7 +29,7 @@ export const useColumnSearchProps = <RecordType extends object>(
 
   useEffect(() => {
     handleSearch()
-  }, [searchText, onSearchTextChange, handleSearch])
+  }, [searchText, onSearch, handleSearch])
 
   return {
     filterDropdown: ({ setSelectedKeys, confirm, clearFilters }) => (

--- a/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
+++ b/libs/shared/abstract/codegen/src/types.api.graphql.gen.ts
@@ -313,6 +313,7 @@ export type ActionTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -327,6 +328,7 @@ export type ActionTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -1226,6 +1228,7 @@ export type ApiActionWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -1236,6 +1239,7 @@ export type ApiActionWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -2139,6 +2143,7 @@ export type AppTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -2153,6 +2158,7 @@ export type AppTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -2221,6 +2227,7 @@ export type AppWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -2231,6 +2238,7 @@ export type AppWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -2259,6 +2267,7 @@ export type AppWhere = {
   slug_CONTAINS?: InputMaybe<Scalars['String']>
   slug_ENDS_WITH?: InputMaybe<Scalars['String']>
   slug_IN?: InputMaybe<Array<Scalars['String']>>
+  slug_MATCHES?: InputMaybe<Scalars['String']>
   slug_NOT?: InputMaybe<Scalars['String']>
   slug_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   slug_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -3398,6 +3407,7 @@ export type ArrayTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -3414,6 +3424,7 @@ export type ArrayTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -4398,6 +4409,7 @@ export type AtomWhere = {
   icon_CONTAINS?: InputMaybe<Scalars['String']>
   icon_ENDS_WITH?: InputMaybe<Scalars['String']>
   icon_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  icon_MATCHES?: InputMaybe<Scalars['String']>
   icon_NOT?: InputMaybe<Scalars['String']>
   icon_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   icon_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -4408,6 +4420,7 @@ export type AtomWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -4418,6 +4431,7 @@ export type AtomWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -4634,6 +4648,7 @@ export type BaseTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -4648,6 +4663,7 @@ export type BaseTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -4834,6 +4850,7 @@ export type CodeActionWhere = {
   code_CONTAINS?: InputMaybe<Scalars['String']>
   code_ENDS_WITH?: InputMaybe<Scalars['String']>
   code_IN?: InputMaybe<Array<Scalars['String']>>
+  code_MATCHES?: InputMaybe<Scalars['String']>
   code_NOT?: InputMaybe<Scalars['String']>
   code_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   code_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -4844,6 +4861,7 @@ export type CodeActionWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -4854,6 +4872,7 @@ export type CodeActionWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -5099,6 +5118,7 @@ export type CodeMirrorTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -5117,6 +5137,7 @@ export type CodeMirrorTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -5791,6 +5812,7 @@ export type ComponentWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -5801,6 +5823,7 @@ export type ComponentWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -5998,6 +6021,7 @@ export type CreateInfoWhere = {
   bookmark_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_ENDS_WITH?: InputMaybe<Scalars['String']>
   bookmark_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  bookmark_MATCHES?: InputMaybe<Scalars['String']>
   bookmark_NOT?: InputMaybe<Scalars['String']>
   bookmark_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -6195,6 +6219,7 @@ export type DeleteInfoWhere = {
   bookmark_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_ENDS_WITH?: InputMaybe<Scalars['String']>
   bookmark_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  bookmark_MATCHES?: InputMaybe<Scalars['String']>
   bookmark_NOT?: InputMaybe<Scalars['String']>
   bookmark_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   bookmark_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -6485,6 +6510,7 @@ export type DomainWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -6495,6 +6521,7 @@ export type DomainWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9166,6 +9193,7 @@ export type ElementTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -9180,6 +9208,7 @@ export type ElementTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9234,6 +9263,7 @@ export type ElementWhere = {
   customCss_CONTAINS?: InputMaybe<Scalars['String']>
   customCss_ENDS_WITH?: InputMaybe<Scalars['String']>
   customCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  customCss_MATCHES?: InputMaybe<Scalars['String']>
   customCss_NOT?: InputMaybe<Scalars['String']>
   customCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   customCss_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9249,6 +9279,7 @@ export type ElementWhere = {
   guiCss_CONTAINS?: InputMaybe<Scalars['String']>
   guiCss_ENDS_WITH?: InputMaybe<Scalars['String']>
   guiCss_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  guiCss_MATCHES?: InputMaybe<Scalars['String']>
   guiCss_NOT?: InputMaybe<Scalars['String']>
   guiCss_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   guiCss_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9272,6 +9303,7 @@ export type ElementWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -9282,6 +9314,7 @@ export type ElementWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9312,6 +9345,7 @@ export type ElementWhere = {
   postRenderActionId_CONTAINS?: InputMaybe<Scalars['String']>
   postRenderActionId_ENDS_WITH?: InputMaybe<Scalars['String']>
   postRenderActionId_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  postRenderActionId_MATCHES?: InputMaybe<Scalars['String']>
   postRenderActionId_NOT?: InputMaybe<Scalars['String']>
   postRenderActionId_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   postRenderActionId_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9322,6 +9356,7 @@ export type ElementWhere = {
   preRenderActionId_CONTAINS?: InputMaybe<Scalars['String']>
   preRenderActionId_ENDS_WITH?: InputMaybe<Scalars['String']>
   preRenderActionId_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  preRenderActionId_MATCHES?: InputMaybe<Scalars['String']>
   preRenderActionId_NOT?: InputMaybe<Scalars['String']>
   preRenderActionId_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   preRenderActionId_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9350,6 +9385,7 @@ export type ElementWhere = {
   propTransformationJs_CONTAINS?: InputMaybe<Scalars['String']>
   propTransformationJs_ENDS_WITH?: InputMaybe<Scalars['String']>
   propTransformationJs_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  propTransformationJs_MATCHES?: InputMaybe<Scalars['String']>
   propTransformationJs_NOT?: InputMaybe<Scalars['String']>
   propTransformationJs_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   propTransformationJs_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9375,6 +9411,7 @@ export type ElementWhere = {
   renderForEachPropKey_CONTAINS?: InputMaybe<Scalars['String']>
   renderForEachPropKey_ENDS_WITH?: InputMaybe<Scalars['String']>
   renderForEachPropKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  renderForEachPropKey_MATCHES?: InputMaybe<Scalars['String']>
   renderForEachPropKey_NOT?: InputMaybe<Scalars['String']>
   renderForEachPropKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   renderForEachPropKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -9385,6 +9422,7 @@ export type ElementWhere = {
   renderIfPropKey_CONTAINS?: InputMaybe<Scalars['String']>
   renderIfPropKey_ENDS_WITH?: InputMaybe<Scalars['String']>
   renderIfPropKey_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  renderIfPropKey_MATCHES?: InputMaybe<Scalars['String']>
   renderIfPropKey_NOT?: InputMaybe<Scalars['String']>
   renderIfPropKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   renderIfPropKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10019,6 +10057,7 @@ export type EnumTypeValueWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -10029,6 +10068,7 @@ export type EnumTypeValueWhere = {
   key_CONTAINS?: InputMaybe<Scalars['String']>
   key_ENDS_WITH?: InputMaybe<Scalars['String']>
   key_IN?: InputMaybe<Array<Scalars['String']>>
+  key_MATCHES?: InputMaybe<Scalars['String']>
   key_NOT?: InputMaybe<Scalars['String']>
   key_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   key_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10039,6 +10079,7 @@ export type EnumTypeValueWhere = {
   value_CONTAINS?: InputMaybe<Scalars['String']>
   value_ENDS_WITH?: InputMaybe<Scalars['String']>
   value_IN?: InputMaybe<Array<Scalars['String']>>
+  value_MATCHES?: InputMaybe<Scalars['String']>
   value_NOT?: InputMaybe<Scalars['String']>
   value_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   value_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10074,6 +10115,7 @@ export type EnumTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -10088,6 +10130,7 @@ export type EnumTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10434,6 +10477,7 @@ export type FieldWhere = {
   defaultValues_CONTAINS?: InputMaybe<Scalars['String']>
   defaultValues_ENDS_WITH?: InputMaybe<Scalars['String']>
   defaultValues_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  defaultValues_MATCHES?: InputMaybe<Scalars['String']>
   defaultValues_NOT?: InputMaybe<Scalars['String']>
   defaultValues_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   defaultValues_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10444,6 +10488,7 @@ export type FieldWhere = {
   description_CONTAINS?: InputMaybe<Scalars['String']>
   description_ENDS_WITH?: InputMaybe<Scalars['String']>
   description_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  description_MATCHES?: InputMaybe<Scalars['String']>
   description_NOT?: InputMaybe<Scalars['String']>
   description_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   description_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10456,6 +10501,7 @@ export type FieldWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -10466,6 +10512,7 @@ export type FieldWhere = {
   key_CONTAINS?: InputMaybe<Scalars['String']>
   key_ENDS_WITH?: InputMaybe<Scalars['String']>
   key_IN?: InputMaybe<Array<Scalars['String']>>
+  key_MATCHES?: InputMaybe<Scalars['String']>
   key_NOT?: InputMaybe<Scalars['String']>
   key_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   key_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10476,6 +10523,7 @@ export type FieldWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -10486,6 +10534,7 @@ export type FieldWhere = {
   validationRules_CONTAINS?: InputMaybe<Scalars['String']>
   validationRules_ENDS_WITH?: InputMaybe<Scalars['String']>
   validationRules_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  validationRules_MATCHES?: InputMaybe<Scalars['String']>
   validationRules_NOT?: InputMaybe<Scalars['String']>
   validationRules_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   validationRules_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -11099,6 +11148,7 @@ export type HookWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -11437,6 +11487,7 @@ export type IBaseTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -11451,6 +11502,7 @@ export type IBaseTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -12119,6 +12171,7 @@ export type InterfaceTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -12133,6 +12186,7 @@ export type InterfaceTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -12361,6 +12415,7 @@ export type LambdaTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -12375,6 +12430,7 @@ export type LambdaTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -13917,6 +13973,7 @@ export type PageTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -13931,6 +13988,7 @@ export type PageTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -13977,6 +14035,7 @@ export type PageWhere = {
   getServerSideProps_CONTAINS?: InputMaybe<Scalars['String']>
   getServerSideProps_ENDS_WITH?: InputMaybe<Scalars['String']>
   getServerSideProps_IN?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+  getServerSideProps_MATCHES?: InputMaybe<Scalars['String']>
   getServerSideProps_NOT?: InputMaybe<Scalars['String']>
   getServerSideProps_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   getServerSideProps_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -13987,6 +14046,7 @@ export type PageWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -13999,6 +14059,7 @@ export type PageWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -14014,6 +14075,7 @@ export type PageWhere = {
   slug_CONTAINS?: InputMaybe<Scalars['String']>
   slug_ENDS_WITH?: InputMaybe<Scalars['String']>
   slug_IN?: InputMaybe<Array<Scalars['String']>>
+  slug_MATCHES?: InputMaybe<Scalars['String']>
   slug_NOT?: InputMaybe<Scalars['String']>
   slug_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   slug_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -14250,6 +14312,7 @@ export type PrimitiveTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -14264,6 +14327,7 @@ export type PrimitiveTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -15002,6 +15066,7 @@ export type PropMapBindingWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -15012,6 +15077,7 @@ export type PropMapBindingWhere = {
   sourceKey_CONTAINS?: InputMaybe<Scalars['String']>
   sourceKey_ENDS_WITH?: InputMaybe<Scalars['String']>
   sourceKey_IN?: InputMaybe<Array<Scalars['String']>>
+  sourceKey_MATCHES?: InputMaybe<Scalars['String']>
   sourceKey_NOT?: InputMaybe<Scalars['String']>
   sourceKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   sourceKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -15027,6 +15093,7 @@ export type PropMapBindingWhere = {
   targetKey_CONTAINS?: InputMaybe<Scalars['String']>
   targetKey_ENDS_WITH?: InputMaybe<Scalars['String']>
   targetKey_IN?: InputMaybe<Array<Scalars['String']>>
+  targetKey_MATCHES?: InputMaybe<Scalars['String']>
   targetKey_NOT?: InputMaybe<Scalars['String']>
   targetKey_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   targetKey_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -15074,6 +15141,7 @@ export type PropWhere = {
   data_CONTAINS?: InputMaybe<Scalars['String']>
   data_ENDS_WITH?: InputMaybe<Scalars['String']>
   data_IN?: InputMaybe<Array<Scalars['String']>>
+  data_MATCHES?: InputMaybe<Scalars['String']>
   data_NOT?: InputMaybe<Scalars['String']>
   data_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   data_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -15084,6 +15152,7 @@ export type PropWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -16076,6 +16145,7 @@ export type ReactNodeTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -16090,6 +16160,7 @@ export type ReactNodeTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -16358,6 +16429,7 @@ export type RenderPropsTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -16372,6 +16444,7 @@ export type RenderPropsTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -16804,6 +16877,7 @@ export type ResourceWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -16814,6 +16888,7 @@ export type ResourceWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -17456,6 +17531,7 @@ export type StoreWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -17466,6 +17542,7 @@ export type StoreWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -18083,6 +18160,7 @@ export type TagWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -18093,6 +18171,7 @@ export type TagWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -18185,6 +18264,7 @@ export type TypeReferenceWhere = {
   label_CONTAINS?: InputMaybe<Scalars['String']>
   label_ENDS_WITH?: InputMaybe<Scalars['String']>
   label_IN?: InputMaybe<Array<Scalars['String']>>
+  label_MATCHES?: InputMaybe<Scalars['String']>
   label_NOT?: InputMaybe<Scalars['String']>
   label_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   label_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -18195,6 +18275,7 @@ export type TypeReferenceWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -19643,6 +19724,7 @@ export type UnionTypeWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -19657,6 +19739,7 @@ export type UnionTypeWhere = {
   name_CONTAINS?: InputMaybe<Scalars['String']>
   name_ENDS_WITH?: InputMaybe<Scalars['String']>
   name_IN?: InputMaybe<Array<Scalars['String']>>
+  name_MATCHES?: InputMaybe<Scalars['String']>
   name_NOT?: InputMaybe<Scalars['String']>
   name_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   name_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -20919,6 +21002,7 @@ export type UserWhere = {
   auth0Id_CONTAINS?: InputMaybe<Scalars['String']>
   auth0Id_ENDS_WITH?: InputMaybe<Scalars['String']>
   auth0Id_IN?: InputMaybe<Array<Scalars['String']>>
+  auth0Id_MATCHES?: InputMaybe<Scalars['String']>
   auth0Id_NOT?: InputMaybe<Scalars['String']>
   auth0Id_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   auth0Id_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -20955,6 +21039,7 @@ export type UserWhere = {
   email_CONTAINS?: InputMaybe<Scalars['String']>
   email_ENDS_WITH?: InputMaybe<Scalars['String']>
   email_IN?: InputMaybe<Array<Scalars['String']>>
+  email_MATCHES?: InputMaybe<Scalars['String']>
   email_NOT?: InputMaybe<Scalars['String']>
   email_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   email_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>
@@ -20965,6 +21050,7 @@ export type UserWhere = {
   id_CONTAINS?: InputMaybe<Scalars['ID']>
   id_ENDS_WITH?: InputMaybe<Scalars['ID']>
   id_IN?: InputMaybe<Array<Scalars['ID']>>
+  id_MATCHES?: InputMaybe<Scalars['String']>
   id_NOT?: InputMaybe<Scalars['ID']>
   id_NOT_CONTAINS?: InputMaybe<Scalars['ID']>
   id_NOT_ENDS_WITH?: InputMaybe<Scalars['ID']>
@@ -21005,6 +21091,7 @@ export type UserWhere = {
   username_CONTAINS?: InputMaybe<Scalars['String']>
   username_ENDS_WITH?: InputMaybe<Scalars['String']>
   username_IN?: InputMaybe<Array<Scalars['String']>>
+  username_MATCHES?: InputMaybe<Scalars['String']>
   username_NOT?: InputMaybe<Scalars['String']>
   username_NOT_CONTAINS?: InputMaybe<Scalars['String']>
   username_NOT_ENDS_WITH?: InputMaybe<Scalars['String']>

--- a/schema.api.graphql
+++ b/schema.api.graphql
@@ -285,6 +285,7 @@ input ActionTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -299,6 +300,7 @@ input ActionTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -1162,6 +1164,7 @@ input ApiActionWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -1172,6 +1175,7 @@ input ApiActionWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -2025,6 +2029,7 @@ input AppTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -2039,6 +2044,7 @@ input AppTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -2116,6 +2122,7 @@ input AppWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -2126,6 +2133,7 @@ input AppWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -2166,6 +2174,7 @@ input AppWhere {
   slug_CONTAINS: String
   slug_ENDS_WITH: String
   slug_IN: [String!]
+  slug_MATCHES: String
   slug_NOT: String
   slug_NOT_CONTAINS: String
   slug_NOT_ENDS_WITH: String
@@ -3256,6 +3265,7 @@ input ArrayTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -3272,6 +3282,7 @@ input ArrayTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -4229,6 +4240,7 @@ input AtomWhere {
   icon_CONTAINS: String
   icon_ENDS_WITH: String
   icon_IN: [String]
+  icon_MATCHES: String
   icon_NOT: String
   icon_NOT_CONTAINS: String
   icon_NOT_ENDS_WITH: String
@@ -4239,6 +4251,7 @@ input AtomWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -4249,6 +4262,7 @@ input AtomWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -4468,6 +4482,7 @@ input BaseTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -4482,6 +4497,7 @@ input BaseTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -4664,6 +4680,7 @@ input CodeActionWhere {
   code_CONTAINS: String
   code_ENDS_WITH: String
   code_IN: [String!]
+  code_MATCHES: String
   code_NOT: String
   code_NOT_CONTAINS: String
   code_NOT_ENDS_WITH: String
@@ -4674,6 +4691,7 @@ input CodeActionWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -4684,6 +4702,7 @@ input CodeActionWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -4917,6 +4936,7 @@ input CodeMirrorTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -4935,6 +4955,7 @@ input CodeMirrorTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -5578,6 +5599,7 @@ input ComponentWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -5588,6 +5610,7 @@ input ComponentWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -5767,6 +5790,7 @@ input CreateInfoWhere {
   bookmark_CONTAINS: String
   bookmark_ENDS_WITH: String
   bookmark_IN: [String]
+  bookmark_MATCHES: String
   bookmark_NOT: String
   bookmark_NOT_CONTAINS: String
   bookmark_NOT_ENDS_WITH: String
@@ -5947,6 +5971,7 @@ input DeleteInfoWhere {
   bookmark_CONTAINS: String
   bookmark_ENDS_WITH: String
   bookmark_IN: [String]
+  bookmark_MATCHES: String
   bookmark_NOT: String
   bookmark_NOT_CONTAINS: String
   bookmark_NOT_ENDS_WITH: String
@@ -6224,6 +6249,7 @@ input DomainWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -6234,6 +6260,7 @@ input DomainWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -8742,6 +8769,7 @@ input ElementTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -8756,6 +8784,7 @@ input ElementTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -8809,6 +8838,7 @@ input ElementWhere {
   customCss_CONTAINS: String
   customCss_ENDS_WITH: String
   customCss_IN: [String]
+  customCss_MATCHES: String
   customCss_NOT: String
   customCss_NOT_CONTAINS: String
   customCss_NOT_ENDS_WITH: String
@@ -8824,6 +8854,7 @@ input ElementWhere {
   guiCss_CONTAINS: String
   guiCss_ENDS_WITH: String
   guiCss_IN: [String]
+  guiCss_MATCHES: String
   guiCss_NOT: String
   guiCss_NOT_CONTAINS: String
   guiCss_NOT_ENDS_WITH: String
@@ -8859,6 +8890,7 @@ input ElementWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -8869,6 +8901,7 @@ input ElementWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -8899,6 +8932,7 @@ input ElementWhere {
   postRenderActionId_CONTAINS: String
   postRenderActionId_ENDS_WITH: String
   postRenderActionId_IN: [String]
+  postRenderActionId_MATCHES: String
   postRenderActionId_NOT: String
   postRenderActionId_NOT_CONTAINS: String
   postRenderActionId_NOT_ENDS_WITH: String
@@ -8909,6 +8943,7 @@ input ElementWhere {
   preRenderActionId_CONTAINS: String
   preRenderActionId_ENDS_WITH: String
   preRenderActionId_IN: [String]
+  preRenderActionId_MATCHES: String
   preRenderActionId_NOT: String
   preRenderActionId_NOT_CONTAINS: String
   preRenderActionId_NOT_ENDS_WITH: String
@@ -8949,6 +8984,7 @@ input ElementWhere {
   propTransformationJs_CONTAINS: String
   propTransformationJs_ENDS_WITH: String
   propTransformationJs_IN: [String]
+  propTransformationJs_MATCHES: String
   propTransformationJs_NOT: String
   propTransformationJs_NOT_CONTAINS: String
   propTransformationJs_NOT_ENDS_WITH: String
@@ -8974,6 +9010,7 @@ input ElementWhere {
   renderForEachPropKey_CONTAINS: String
   renderForEachPropKey_ENDS_WITH: String
   renderForEachPropKey_IN: [String]
+  renderForEachPropKey_MATCHES: String
   renderForEachPropKey_NOT: String
   renderForEachPropKey_NOT_CONTAINS: String
   renderForEachPropKey_NOT_ENDS_WITH: String
@@ -8984,6 +9021,7 @@ input ElementWhere {
   renderIfPropKey_CONTAINS: String
   renderIfPropKey_ENDS_WITH: String
   renderIfPropKey_IN: [String]
+  renderIfPropKey_MATCHES: String
   renderIfPropKey_NOT: String
   renderIfPropKey_NOT_CONTAINS: String
   renderIfPropKey_NOT_ENDS_WITH: String
@@ -9559,6 +9597,7 @@ input EnumTypeValueWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -9569,6 +9608,7 @@ input EnumTypeValueWhere {
   key_CONTAINS: String
   key_ENDS_WITH: String
   key_IN: [String!]
+  key_MATCHES: String
   key_NOT: String
   key_NOT_CONTAINS: String
   key_NOT_ENDS_WITH: String
@@ -9579,6 +9619,7 @@ input EnumTypeValueWhere {
   value_CONTAINS: String
   value_ENDS_WITH: String
   value_IN: [String!]
+  value_MATCHES: String
   value_NOT: String
   value_NOT_CONTAINS: String
   value_NOT_ENDS_WITH: String
@@ -9625,6 +9666,7 @@ input EnumTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -9639,6 +9681,7 @@ input EnumTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -9970,6 +10013,7 @@ input FieldWhere {
   defaultValues_CONTAINS: String
   defaultValues_ENDS_WITH: String
   defaultValues_IN: [String]
+  defaultValues_MATCHES: String
   defaultValues_NOT: String
   defaultValues_NOT_CONTAINS: String
   defaultValues_NOT_ENDS_WITH: String
@@ -9980,6 +10024,7 @@ input FieldWhere {
   description_CONTAINS: String
   description_ENDS_WITH: String
   description_IN: [String]
+  description_MATCHES: String
   description_NOT: String
   description_NOT_CONTAINS: String
   description_NOT_ENDS_WITH: String
@@ -9992,6 +10037,7 @@ input FieldWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -10002,6 +10048,7 @@ input FieldWhere {
   key_CONTAINS: String
   key_ENDS_WITH: String
   key_IN: [String!]
+  key_MATCHES: String
   key_NOT: String
   key_NOT_CONTAINS: String
   key_NOT_ENDS_WITH: String
@@ -10012,6 +10059,7 @@ input FieldWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -10022,6 +10070,7 @@ input FieldWhere {
   validationRules_CONTAINS: String
   validationRules_ENDS_WITH: String
   validationRules_IN: [String]
+  validationRules_MATCHES: String
   validationRules_NOT: String
   validationRules_NOT_CONTAINS: String
   validationRules_NOT_ENDS_WITH: String
@@ -10619,6 +10668,7 @@ input HookWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -10951,6 +11001,7 @@ input IBaseTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -10965,6 +11016,7 @@ input IBaseTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -11611,6 +11663,7 @@ input InterfaceTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -11625,6 +11678,7 @@ input InterfaceTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -11841,6 +11895,7 @@ input LambdaTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -11855,6 +11910,7 @@ input LambdaTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -13072,6 +13128,7 @@ input PageTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -13086,6 +13143,7 @@ input PageTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -13131,6 +13189,7 @@ input PageWhere {
   getServerSideProps_CONTAINS: String
   getServerSideProps_ENDS_WITH: String
   getServerSideProps_IN: [String]
+  getServerSideProps_MATCHES: String
   getServerSideProps_NOT: String
   getServerSideProps_NOT_CONTAINS: String
   getServerSideProps_NOT_ENDS_WITH: String
@@ -13141,6 +13200,7 @@ input PageWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -13153,6 +13213,7 @@ input PageWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -13168,6 +13229,7 @@ input PageWhere {
   slug_CONTAINS: String
   slug_ENDS_WITH: String
   slug_IN: [String!]
+  slug_MATCHES: String
   slug_NOT: String
   slug_NOT_CONTAINS: String
   slug_NOT_ENDS_WITH: String
@@ -13392,6 +13454,7 @@ input PrimitiveTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -13406,6 +13469,7 @@ input PrimitiveTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -14122,6 +14186,7 @@ input PropMapBindingWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -14132,6 +14197,7 @@ input PropMapBindingWhere {
   sourceKey_CONTAINS: String
   sourceKey_ENDS_WITH: String
   sourceKey_IN: [String!]
+  sourceKey_MATCHES: String
   sourceKey_NOT: String
   sourceKey_NOT_CONTAINS: String
   sourceKey_NOT_ENDS_WITH: String
@@ -14147,6 +14213,7 @@ input PropMapBindingWhere {
   targetKey_CONTAINS: String
   targetKey_ENDS_WITH: String
   targetKey_IN: [String!]
+  targetKey_MATCHES: String
   targetKey_NOT: String
   targetKey_NOT_CONTAINS: String
   targetKey_NOT_ENDS_WITH: String
@@ -14198,6 +14265,7 @@ input PropWhere {
   data_CONTAINS: String
   data_ENDS_WITH: String
   data_IN: [String!]
+  data_MATCHES: String
   data_NOT: String
   data_NOT_CONTAINS: String
   data_NOT_ENDS_WITH: String
@@ -14208,6 +14276,7 @@ input PropWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -14820,6 +14889,7 @@ input ReactNodeTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -14834,6 +14904,7 @@ input ReactNodeTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -15058,6 +15129,7 @@ input RenderPropsTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -15072,6 +15144,7 @@ input RenderPropsTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -15484,6 +15557,7 @@ input ResourceWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -15494,6 +15568,7 @@ input ResourceWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -16102,6 +16177,7 @@ input StoreWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -16112,6 +16188,7 @@ input StoreWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -16702,6 +16779,7 @@ input TagWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -16712,6 +16790,7 @@ input TagWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -16810,6 +16889,7 @@ input TypeReferenceWhere {
   label_CONTAINS: String
   label_ENDS_WITH: String
   label_IN: [String!]
+  label_MATCHES: String
   label_NOT: String
   label_NOT_CONTAINS: String
   label_NOT_ENDS_WITH: String
@@ -16820,6 +16900,7 @@ input TypeReferenceWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -17905,6 +17986,7 @@ input UnionTypeWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -17919,6 +18001,7 @@ input UnionTypeWhere {
   name_CONTAINS: String
   name_ENDS_WITH: String
   name_IN: [String!]
+  name_MATCHES: String
   name_NOT: String
   name_NOT_CONTAINS: String
   name_NOT_ENDS_WITH: String
@@ -19099,6 +19182,7 @@ input UserWhere {
   auth0Id_CONTAINS: String
   auth0Id_ENDS_WITH: String
   auth0Id_IN: [String!]
+  auth0Id_MATCHES: String
   auth0Id_NOT: String
   auth0Id_NOT_CONTAINS: String
   auth0Id_NOT_ENDS_WITH: String
@@ -19159,6 +19243,7 @@ input UserWhere {
   email_CONTAINS: String
   email_ENDS_WITH: String
   email_IN: [String!]
+  email_MATCHES: String
   email_NOT: String
   email_NOT_CONTAINS: String
   email_NOT_ENDS_WITH: String
@@ -19169,6 +19254,7 @@ input UserWhere {
   id_CONTAINS: ID
   id_ENDS_WITH: ID
   id_IN: [ID!]
+  id_MATCHES: String
   id_NOT: ID
   id_NOT_CONTAINS: ID
   id_NOT_ENDS_WITH: ID
@@ -19233,6 +19319,7 @@ input UserWhere {
   username_CONTAINS: String
   username_ENDS_WITH: String
   username_IN: [String!]
+  username_MATCHES: String
   username_NOT: String
   username_NOT_CONTAINS: String
   username_NOT_ENDS_WITH: String


### PR DESCRIPTION
## Description (Optional)

TODO:
- [x] Fix custom atom resolver not accepting where arguments
- [x] Send a query with name_CONTAINS argument each time the filter is changed and update local cache.
- [x] Fix pagination (currently always shows the number of pages based on all atoms regardless of the filer). We should see the number of pages based on how many items available given the provided filter.
- [x] Make the search case-insensitive?

## Related Issue(s)
Fixes #1991