### PR TITLE
fix(libs-frontend): set the highest precedence to gui css rules (#2048)

### DIFF
--- a/libs/frontend/domain/renderer/src/renderPipes/atomRenderPipe.ts
+++ b/libs/frontend/domain/renderer/src/renderPipes/atomRenderPipe.ts
@@ -10,6 +10,7 @@ import { ArrayOrSingle } from 'ts-essentials'
 import { RenderOutput } from '../abstract/RenderOutput'
 import { atomFactory } from '../atoms'
 import { evalCss } from '../utils/evalCss'
+import { increaseCssPrecedence } from '../utils/increaseCssPrecedence'
 import { BaseRenderPipe } from './renderPipe.base'
 
 @model('@codelab/AtomRenderPipe')
@@ -45,7 +46,7 @@ export class AtomRenderPipe
     const elCss =
       element.customCss || element.guiCss
         ? css([
-            JSON.parse(element.guiCss || '{}'),
+            increaseCssPrecedence(element.guiCss || '{}'),
             evalCss(element.customCss || ''),
           ])
         : undefined

--- a/libs/frontend/domain/renderer/src/test/increaseCssPrecedence.spec.ts
+++ b/libs/frontend/domain/renderer/src/test/increaseCssPrecedence.spec.ts
@@ -1,0 +1,26 @@
+import { increaseCssPrecedence } from '../utils/increaseCssPrecedence'
+
+describe('increaseCssPrecedence', () => {
+  const testCss = {
+    display: 'flex',
+    padding: 0,
+  }
+
+  it('should increase precedence for each prop when parameter is css string', async () => {
+    const result = increaseCssPrecedence(JSON.stringify(testCss))
+
+    expect(result).toEqual({
+      display: 'flex !important;',
+      padding: '0 !important;',
+    })
+  })
+
+  it('should increase precedence for each prop when parameter is css object', async () => {
+    const result = increaseCssPrecedence(testCss)
+
+    expect(result).toEqual({
+      display: 'flex !important;',
+      padding: '0 !important;',
+    })
+  })
+})

--- a/libs/frontend/domain/renderer/src/utils/increaseCssPrecedence.ts
+++ b/libs/frontend/domain/renderer/src/utils/increaseCssPrecedence.ts
@@ -1,0 +1,14 @@
+import { mapDeep } from '@codelab/shared/utils'
+import isNumber from 'lodash/isNumber'
+import isString from 'lodash/isString'
+
+export const increaseCssPrecedence = (
+  guiCss: string | Record<string, unknown>,
+) => {
+  const parsedStyleObject =
+    typeof guiCss === 'string' ? JSON.parse(guiCss) : guiCss
+
+  return mapDeep(parsedStyleObject, (value) =>
+    isNumber(value) || isString(value) ? `${value} !important;` : value,
+  )
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Since we support lots of components in a different UI frameworks (antd, mui) it is important to set higher precedence for our custom styles, so that they for sure are applied and not overriden by default styles of components
<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2048 
