### PR TITLE
fix(libs-frontend-domain): fix user style precedence (#2048)

### DIFF
--- a/libs/frontend/domain/renderer/src/Renderer.tsx
+++ b/libs/frontend/domain/renderer/src/Renderer.tsx
@@ -2,6 +2,8 @@ import {
   IRenderer,
   ROOT_RENDER_CONTAINER_ID,
 } from '@codelab/frontend/abstract/core'
+import createCache from '@emotion/cache'
+import { CacheProvider } from '@emotion/react'
 import ErrorBoundary from 'antd/lib/alert/ErrorBoundary'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
@@ -30,15 +32,23 @@ export type RendererRoot = Pick<IRenderer, 'renderRoot'>
  *
  * Hooks and prop map bindings are currently not implemented, since they might be replaced by platform-level mobx.
  */
+
+const emotionCache = createCache({
+  key: ROOT_RENDER_CONTAINER_ID,
+  prepend: false,
+})
+
 export const Renderer = observer<RendererRoot>(({ renderRoot }) => {
   return (
     <ErrorBoundary>
-      <div
-        id={ROOT_RENDER_CONTAINER_ID}
-        style={{ minHeight: '100%', transform: 'translatex(0)' }}
-      >
-        {renderRoot()}
-      </div>
+      <CacheProvider value={emotionCache}>
+        <div
+          id={ROOT_RENDER_CONTAINER_ID}
+          style={{ minHeight: '100%', transform: 'translatex(0)' }}
+        >
+          {renderRoot()}
+        </div>
+      </CacheProvider>
     </ErrorBoundary>
   )
 })


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
emotion inserts style tags with user classes in the top of the head and the antd styles are inserted later which gives them higher priority. Add emotion wrapper for the app and setup emotion to append style tag at the bottom of the head

Before            |  After
:-------------------------:|:-------------------------:
<img width="474" alt="Screenshot 2022-12-07 at 21 57 18" src="https://user-images.githubusercontent.com/74900868/206282798-0b435e33-eb6d-43ae-a701-c2f3fbb5b515.png">|<img width="469" alt="Screenshot 2022-12-07 at 21 55 31" src="https://user-images.githubusercontent.com/74900868/206282507-e2b2be50-da94-441b-b24e-cb60def8ebb0.png">

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2048 
