### PR TITLE
fix: PART 1: load babel transpiler using dynamic import (-50% bundle size) (#2101)

### DIFF
--- a/apps/builder/pages/_sites/user/[user]/[app]/[page]/index.tsx
+++ b/apps/builder/pages/_sites/user/[user]/[app]/[page]/index.tsx
@@ -4,14 +4,13 @@ import { initializeStore } from '@codelab/frontend/model/infra/mobx'
 import { useStore } from '@codelab/frontend/presenter/container'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import Head from 'next/head'
-import { useRouter } from 'next/router'
-import React, { useMemo } from 'react'
+import React from 'react'
+import { useAsync } from 'react-use'
 
 const Index = (props: AppPagePageProps) => {
   const store = useStore()
 
   const {
-    userService,
     storeService,
     componentService,
     pageService,
@@ -19,19 +18,18 @@ const Index = (props: AppPagePageProps) => {
     builderRenderService,
   } = store
 
-  const router = useRouter()
   const { pageId, storeId, appId } = props
   const app = appService.app(appId)
   const appStore = storeService.store(storeId)
   const page = pageService.pages.get(pageId)
   const components = componentService.componentList
 
-  const renderer = useMemo(() => {
+  const { value: renderer } = useAsync(async () => {
     if (!page || !appStore || !app) {
       return
     }
 
-    const result = builderRenderService.addRenderer({
+    const result = await builderRenderService.addRenderer({
       id: pageId,
       pageTree: page.elementTree,
       appTree: null,

--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/index.tsx
@@ -29,7 +29,7 @@ const PageRenderer: CodelabPage = observer(() => {
 
     const { page, pageTree, appTree, appStore, components } = pageDataValue
 
-    const renderer = appRenderService.addRenderer({
+    const renderer = await appRenderService.addRenderer({
       id: page.id,
       pageTree,
       appTree,

--- a/libs/frontend/abstract/core/src/domain/builder/render.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/render.service.interface.ts
@@ -17,7 +17,7 @@ export interface RendererProps {
 
 export interface IRenderService {
   renderers: ObjectMap<IRenderer>
-  addRenderer(props: RendererProps & { id: string }): IRenderer
+  addRenderer(props: RendererProps & { id: string }): Promise<IRenderer>
   // componentService: IComponentService
   // elementService: IElementService
 }

--- a/libs/frontend/domain/renderer/src/render.service.ts
+++ b/libs/frontend/domain/renderer/src/render.service.ts
@@ -27,11 +27,11 @@ export class RenderService
   // }
 
   @modelAction
-  addRenderer(props: RendererProps & { id: string }) {
+  async addRenderer(props: RendererProps & { id: string }) {
     const existing = this.renderers.get(props.id)
 
     if (!existing) {
-      const renderer = Renderer.init(props)
+      const renderer = await Renderer.init(props)
 
       this.renderers.set(props.id, renderer)
 

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -13,6 +13,7 @@ import { elementRef, elementTreeRef } from '@codelab/frontend/domain/element'
 import { getActionService, storeRef } from '@codelab/frontend/domain/store'
 import { getTypeService } from '@codelab/frontend/domain/type'
 import { getElementService } from '@codelab/frontend/presenter/container'
+import { babelTransformer } from '@codelab/frontend/shared/utils'
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import { mapDeep, mergeProps } from '@codelab/shared/utils'
@@ -64,7 +65,7 @@ import { mapOutput } from './utils/renderOutputUtils'
  * For example - we use the renderContext from ./renderContext inside the pipes to get the renderer model itself and its tree.
  */
 
-const init = ({
+const init = async ({
   pageTree,
   appStore,
   appTree,
@@ -95,6 +96,8 @@ const init = ({
   const renderComponentMeta = components
     .map((c) => ({ [c.id]: 0 }))
     .reduce(merge, {})
+
+  await babelTransformer.init()
 
   return new Renderer({
     appTree: appTree ? elementTreeRef(appTree) : null,

--- a/libs/frontend/domain/renderer/src/typedValueTransformers/ReactNodeTypedValueTransformer.ts
+++ b/libs/frontend/domain/renderer/src/typedValueTransformers/ReactNodeTypedValueTransformer.ts
@@ -4,8 +4,8 @@ import {
   getElementService,
 } from '@codelab/frontend/presenter/container'
 import {
+  babelTransformer,
   hasStateExpression,
-  transpileAndEvaluateExpression,
 } from '@codelab/frontend/shared/utils'
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
@@ -55,7 +55,7 @@ export class ReactNodeTypedValueTransformer
       const atoms = { ...htmlAtoms, ...codelabAtoms, ...antdAtoms, ...muiAtoms }
       const evaluationContext = { React, atoms, ...values }
 
-      const transpiledValue = transpileAndEvaluateExpression(
+      const transpiledValue = babelTransformer.transpileAndEvaluateExpression(
         value.value,
         evaluationContext,
       )

--- a/libs/frontend/domain/renderer/src/typedValueTransformers/RenderPropsTypedValueTransformer.ts
+++ b/libs/frontend/domain/renderer/src/typedValueTransformers/RenderPropsTypedValueTransformer.ts
@@ -4,8 +4,8 @@ import {
   getElementService,
 } from '@codelab/frontend/presenter/container'
 import {
+  babelTransformer,
   hasStateExpression,
-  transpileAndEvaluateExpression,
 } from '@codelab/frontend/shared/utils'
 import { ITypeKind } from '@codelab/shared/abstract/core'
 import { ExtendedModel, model } from 'mobx-keystone'
@@ -53,12 +53,12 @@ export class RenderPropsTypedValueTransformer
     if (hasStateExpression(value.value)) {
       const { values } = this.renderer.appStore.current.state
       const atoms = { ...htmlAtoms, ...codelabAtoms, ...antdAtoms, ...muiAtoms }
+      const evaluationContext = { React, atoms, ...values }
 
-      return transpileAndEvaluateExpression(value.value, {
-        React,
-        atoms,
-        ...values,
-      })
+      return babelTransformer.transpileAndEvaluateExpression(
+        value.value,
+        evaluationContext,
+      )
     }
 
     const componentService = getComponentService(this)

--- a/libs/frontend/shared/utils/src/stateExpressions.ts
+++ b/libs/frontend/shared/utils/src/stateExpressions.ts
@@ -1,13 +1,11 @@
-import jsxPlugin from '@babel/plugin-transform-react-jsx'
-import { registerPlugin, transform } from '@babel/standalone'
+import type { BabelFileResult, TransformOptions } from '@babel/core'
 import {
   IPropData,
   STATE_PATH_TEMPLATE_END,
   STATE_PATH_TEMPLATE_START,
 } from '@codelab/frontend/abstract/core'
+import type { Nullable } from '@codelab/shared/abstract/types'
 import isString from 'lodash/isString'
-
-registerPlugin('@babel/plugin-transform-react-jsx', jsxPlugin)
 
 export const hasStateExpression = (str: string): boolean =>
   isString(str) &&
@@ -37,26 +35,63 @@ export const evaluateExpression = (
   }
 }
 
-export const transpileAndEvaluateExpression = (
-  expression: string,
-  evaluationContext: IPropData,
-) => {
-  try {
-    const wrappedExpression = `(function getResult() {
-      const { React } = this
+interface BabelTransformer {
+  initialized: boolean
+  transform: Nullable<
+    (code: string, options: TransformOptions) => BabelFileResult
+  >
+  init: () => Promise<void>
+  transpileAndEvaluateExpression: (
+    expression: string,
+    evaluationContext: IPropData,
+  ) => unknown
+}
 
-      return ${stripStateExpression(expression)}
-    }).call(this)`
+export const babelTransformer: BabelTransformer = {
+  transform: null,
+  initialized: false,
+  init: async function () {
+    if (this.initialized) {
+      return
+    }
 
-    const { code } = transform(wrappedExpression, {
-      plugins: ['@babel/plugin-transform-react-jsx'],
-    })
+    const [jsxPlugin, { registerPlugin, transform }] = await Promise.all([
+      import('@babel/plugin-transform-react-jsx'),
+      import('@babel/standalone'),
+    ])
 
-    // eslint-disable-next-line no-new-func
-    return new Function('return ' + (code ?? '')).call(evaluationContext)
-  } catch (error) {
-    console.log(error)
+    registerPlugin('@babel/plugin-transform-react-jsx', jsxPlugin)
 
-    return expression
-  }
+    this.transform = transform
+    this.initialized = true
+  },
+  transpileAndEvaluateExpression: function (
+    expression: string,
+    evaluationContext: IPropData,
+  ) {
+    if (!this.transform) {
+      throw new Error(
+        'BabelExpressionsTranspiler needs to be initialized first. Make sure to call "init" first.',
+      )
+    }
+
+    try {
+      const wrappedExpression = `(function getResult() {
+            const { React } = this
+      
+            return ${stripStateExpression(expression)}
+          }).call(this)`
+
+      const { code } = this.transform(wrappedExpression, {
+        plugins: ['@babel/plugin-transform-react-jsx'],
+      })
+
+      // eslint-disable-next-line no-new-func
+      return new Function('return ' + (code ?? '')).call(evaluationContext)
+    } catch (error) {
+      console.log(error)
+
+      return expression
+    }
+  },
 }


### PR DESCRIPTION


<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
After expressions with JSX transpilation were added the bundle size increased a lot. Load the "babel" package dynamically in order to fix this

Before            |  After
:-------------------------:|:-------------------------:
<img width="477" alt="Before - Bundle Size" src="https://user-images.githubusercontent.com/74900868/207107196-2c48119a-710c-4c15-b72d-795bf1884e5e.png">|<img width="472" alt="Screenshot 2022-12-12 at 19 01 58" src="https://user-images.githubusercontent.com/74900868/207107508-7503e3c1-a5c1-4503-8fdc-f0d2453730eb.png">

<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
