### PR TITLE
fix: fix preview builds on PRs

### DIFF
--- a/libs/frontend/domain/app/src/store/app.service.ts
+++ b/libs/frontend/domain/app/src/store/app.service.ts
@@ -186,7 +186,7 @@ export class AppService
       const providerPage = {
         id: pageId,
         name: APP_PAGE_NAME,
-        slug: APP_PAGE_SLUG,
+        slug: `${appId}-${APP_PAGE_SLUG}`,
         getServerSideProps: DEFAULT_GET_SERVER_SIDE_PROPS,
         app: {
           connect: { where: { node: { id: appId } } },

--- a/libs/shared/adapter/logging/src/winston-driver.ts
+++ b/libs/shared/adapter/logging/src/winston-driver.ts
@@ -35,12 +35,16 @@ export const logger = createLogger({
       level: 'info',
     }),
 
-    new transports.File({
+    // The File transporters do not work on deployed builds on Vercel.
+    // File system is readonly for serverless functions, so can't create and write logs to files.
+    // The recommended way to handle logs is to use so called log drains:
+    // https://vercel.com/docs/integrations/log-drains-overview/log-drains-reference
+    /* new transports.File({
       filename: 'logs/info.log',
       level: 'info',
     }),
     new transports.File({ filename: 'logs/error.log', level: 'error' }),
-    new transports.File({ filename: 'logs/combined.log' }),
+    new transports.File({ filename: 'logs/combined.log' }), */
   ],
 })
 

--- a/libs/shared/config/src/flags.ts
+++ b/libs/shared/config/src/flags.ts
@@ -10,8 +10,12 @@ export const isCi =
   // Others may use 'true'
   process.env['CI'] === 'true'
 
-export const isVercelPreview = process.env['VERCEL_ENV'] === 'preview'
+export const isVercelPreview =
+  process.env['VERCEL_ENV'] === 'preview' ||
+  Boolean(process.env['NEXT_PUBLIC_VERCEL_URL'])
 
-export const isVercel = process.env['VERCEL'] === '1'
+export const isVercel =
+  process.env['VERCEL'] === '1' ||
+  Boolean(process.env['NEXT_PUBLIC_VERCEL_URL'])
 
 export const isCircleCi = process.env['CIRCLECI'] === 'true'

--- a/libs/shared/config/src/graphql.ts
+++ b/libs/shared/config/src/graphql.ts
@@ -2,7 +2,10 @@ import { isCircleCi, isProduction, isVercel } from './flags'
 
 const graphqlApiHost =
   isProduction && isVercel && !isCircleCi
-    ? `https://${process.env['NEXT_PUBLIC_VERCEL_URL']}`
-    : `http://${process.env['NEXT_PUBLIC_BUILDER_HOST']}`
+    ? process.env['NEXT_PUBLIC_VERCEL_URL']
+    : process.env['NEXT_PUBLIC_BUILDER_HOST']
 
-export const graphqlApiOrigin = `${graphqlApiHost}/api/graphql`
+const isDev = graphqlApiHost?.startsWith('127.0.0.1')
+const protocol = isDev ? 'http' : 'https'
+
+export const graphqlApiOrigin = `${protocol}://${graphqlApiHost}/api/graphql`


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Preview builds for the builder app were broken. In this PR couple of issues are solved:
- mixed protocols error: the app uses HTTPS protocol to load all the resources but HTTP for graphql endpoint. Browsers block requests in such situations for security reasons. 
- serverless functions on vercel can not access the file system (it is read-only). So our logger failed on an attempt to write logs to files and the graphql endpoint crashed. Disabled login to file system for now.
- graphql requests for all preview builds share the same endpoint - `https://admin.codelab.app/api/graphql`. This causes the requests to fail because of the CORS issue. Use the graphql endpoint that is on the same origin (endpoint of the preview build)
- fix the error on creating the second app. Pages `slug` property was unique across all applications, which is a mistake. Make it unique per application

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
