### PR TITLE
fix: types table - nested table Type and Kind empty (#2117)

### DIFF
--- a/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
@@ -101,10 +101,14 @@ export const GetTypesTable = observer<{
     }
   }, [typeId, rowClassReady])
 
+  const currentPageTypes = typesList.length
+    ? typesList.slice((curPage - 1) * curPageSize, curPage * curPageSize)
+    : []
+
   return (
     <Table<IAnyType>
       columns={columns}
-      dataSource={typesList}
+      dataSource={currentPageTypes}
       expandable={{
         defaultExpandedRowKeys: [typeId ?? ''],
         expandedRowRender: (type) =>


### PR DESCRIPTION
* fix(libs-frontend-domain-type) fetch missing types for the nested types table
* fix(libs-frontend-domain-type) getTypesTable use only current page values for datasource

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)
Fix empty kind and type values in nested fields table by fetching the missing types.
<!-- This is a short description on the Pull Request -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2117
