### PR TITLE
feat(apps-builder): implement editing of type API in the builder page

### DIFF
--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -138,17 +138,10 @@ PageBuilder.Layout = observer((page) => {
     () =>
       observer(() => (
         <ConfigPane
-          actionService={actionService}
-          atomService={atomService}
-          builderService={builderService}
-          componentService={componentService}
-          elementService={elementService}
           // The element tree changes depending on whether a page or a component is selected
           elementTree={activeElementTree}
           key={pageBuilderRenderer?.pageTree?.current.root?.id}
           renderService={pageBuilderRenderer}
-          typeService={typeService}
-          userService={userService}
         />
       )),
     [pageBuilderRenderer, builderService],

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-InspectorTabContainer/ConfigPane-InspectorTabContainer.tsx
@@ -7,15 +7,9 @@ import {
   SwapOutlined,
 } from '@ant-design/icons'
 import type {
-  IActionService,
-  IAtomService,
-  IBuilderService,
-  IElementService,
   IElementTree,
   INode,
   IRenderer,
-  ITypeService,
-  IUserService,
 } from '@codelab/frontend/abstract/core'
 import { isElement } from '@codelab/frontend/abstract/core'
 import {
@@ -24,6 +18,7 @@ import {
   UpdateElementPropsForm,
   UpdateElementPropTransformationForm,
 } from '@codelab/frontend/domain/element'
+import { useStore } from '@codelab/frontend/presenter/container'
 import type { UseTrackLoadingPromises } from '@codelab/frontend/view/components'
 import {
   FormContextProvider,
@@ -48,12 +43,6 @@ export interface MetaPaneBuilderProps {
     node: INode
     trackPromises: UseTrackLoadingPromises
   }) => React.ReactElement | null
-  typeService: ITypeService
-  atomService: IAtomService
-  builderService: IBuilderService
-  elementService: IElementService
-  actionService: IActionService
-  userService: IUserService
 }
 
 interface TooltipIconProps {
@@ -77,15 +66,8 @@ const TooltipIcon = ({ title, icon }: TooltipIconProps) => {
 }
 
 export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
-  ({
-    userService,
-    UpdateElementContent,
-    typeService,
-    elementTree,
-    builderService,
-    renderService,
-    elementService,
-  }) => {
+  ({ UpdateElementContent, elementTree, renderService }) => {
+    const { builderService, elementService } = useStore()
     const selectedNode = builderService.selectedNode
     const { providePropCompletion } = usePropCompletion(renderService)
     const trackPromises = useTrackLoadingPromises()
@@ -131,10 +113,7 @@ export const ConfigPaneInspectorTabContainer = observer<MetaPaneBuilderProps>(
               >
                 <UpdateElementPropsForm
                   element={selectedNode}
-                  elementService={elementService}
                   trackPromises={trackPromises}
-                  typeService={typeService}
-                  userService={userService}
                 />
               </FormContextProvider>
             ) : (

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane.tsx
@@ -1,15 +1,5 @@
 import { CodeSandboxOutlined, EditOutlined } from '@ant-design/icons'
-import type {
-  IActionService,
-  IAtomService,
-  IBuilderService,
-  IComponentService,
-  IElementService,
-  IElementTree,
-  IRenderer,
-  ITypeService,
-  IUserService,
-} from '@codelab/frontend/abstract/core'
+import type { IElementTree, IRenderer } from '@codelab/frontend/abstract/core'
 import {
   COMPONENT_NODE_TYPE,
   ELEMENT_NODE_TYPE,
@@ -20,6 +10,7 @@ import {
   MoveElementForm,
   UpdateElementForm,
 } from '@codelab/frontend/domain/element'
+import { useStore } from '@codelab/frontend/presenter/container'
 import { Spin, Tabs } from 'antd'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
@@ -32,27 +23,11 @@ import { TabContainer } from './ConfigPane-InspectorTabContainer/ConfigPane-Insp
 interface MetaPaneProps {
   elementTree?: IElementTree
   renderService?: IRenderer
-  atomService: IAtomService
-  typeService: ITypeService
-  builderService: IBuilderService
-  elementService: IElementService
-  componentService: IComponentService
-  actionService: IActionService
-  userService: IUserService
 }
 
 export const ConfigPane = observer<MetaPaneProps>(
-  ({
-    typeService,
-    atomService,
-    builderService,
-    elementService,
-    componentService,
-    renderService,
-    elementTree,
-    actionService,
-    userService,
-  }) => {
+  ({ renderService, elementTree }) => {
+    const { builderService, elementService, componentService } = useStore()
     const { providePropCompletion } = usePropCompletion(renderService)
     const selectedNode = builderService.selectedNode
 
@@ -111,14 +86,8 @@ export const ConfigPane = observer<MetaPaneProps>(
                 </>
               )
             })}
-            actionService={actionService}
-            atomService={atomService}
-            builderService={builderService}
-            elementService={elementService}
             elementTree={elementTree}
             renderService={renderService}
-            typeService={typeService}
-            userService={userService}
           />
         ),
       },


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

<!-- This is a short description on the Pull Request -->
- can now add, edit, or delete a prop on the builder page

[edit-type-on-builder.webm](https://user-images.githubusercontent.com/27695022/211051824-09d1bb73-9a9c-4365-8f80-f71f5f1b13e6.webm)

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2136 
