### PR TITLE
fix: paginating non-adjacent pages

### DIFF
--- a/apps/builder/pages/types/index.tsx
+++ b/apps/builder/pages/types/index.tsx
@@ -8,7 +8,6 @@ import {
   GetTypesTable,
   UpdateFieldModal,
   UpdateTypeModal,
-  useCurrentTypeId,
 } from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
@@ -51,7 +50,6 @@ const Header = observer(() => {
 })
 
 const TypesPage: CodelabPage<DashboardTemplateProps> = observer(() => {
-  const typeId = useCurrentTypeId()
   const { userService, typeService, fieldService } = useStore()
 
   return (
@@ -67,11 +65,7 @@ const TypesPage: CodelabPage<DashboardTemplateProps> = observer(() => {
       <DeleteTypeModal typeService={typeService} />
       <UpdateTypeModal typeService={typeService} />
       <ContentSection>
-        <GetTypesTable
-          fieldService={fieldService}
-          typeId={typeId}
-          typeService={typeService}
-        />
+        <GetTypesTable fieldService={fieldService} typeService={typeService} />
       </ContentSection>
     </>
   )

--- a/libs/backend/application/src/repositories/atom/atom.repo.ts
+++ b/libs/backend/application/src/repositories/atom/atom.repo.ts
@@ -1,3 +1,4 @@
+import { OGM_TYPES } from '@codelab/backend/abstract/codegen'
 import {
   atomSelectionSet,
   Repository,
@@ -28,6 +29,11 @@ export const atomRepository = {
       where: params.where as any,
       selectionSet: `{ id }`,
       options: {
+        sort: [
+          {
+            name: OGM_TYPES.SortDirection.Asc,
+          },
+        ],
         limit,
         offset,
       },
@@ -39,6 +45,13 @@ export const atomRepository = {
           return (
             await AtomInstance.find({
               where: { id: item.id },
+              options: {
+                sort: [
+                  {
+                    name: OGM_TYPES.SortDirection.Asc,
+                  },
+                ],
+              },
               selectionSet: atomSelectionSet.replace(
                 /tags {([a-z]|\s)*}/g,
                 `tags ${tagSelectionSet}`,

--- a/libs/frontend/domain/type/src/store/type.service.ts
+++ b/libs/frontend/domain/type/src/store/type.service.ts
@@ -198,9 +198,16 @@ export class TypeService
     const ids = where?.id_IN ?? undefined
     const types = yield* _await(getAllTypes(ids))
 
-    return types.map((type) => {
-      return this.writeCache(type)
-    })
+    return (
+      types
+        .map((type) => {
+          return this.writeCache(type)
+        })
+        // Sort the most recently fetched types
+        .sort((typeA, typeB) =>
+          typeA.name.toLowerCase() < typeB.name.toLowerCase() ? -1 : 1,
+        )
+    )
   })
 
   getType(id: string) {

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
@@ -3,24 +3,18 @@ import type {
   IFieldService,
   ITypeService,
 } from '@codelab/frontend/abstract/core'
-import { PageType } from '@codelab/frontend/abstract/types'
 import { Spin, Table } from 'antd'
 import { observer } from 'mobx-react-lite'
-import { useRouter } from 'next/router'
 import React, { useCallback, useEffect, useState } from 'react'
-import scrollIntoView from 'scroll-into-view'
 import { TypeDetailsTable } from './tables/TypeDetailsTable'
 import { useTypesTable } from './useTypesTable'
 import { useTypesTableData } from './useTypesTableData'
 
-const SCROLL_ROW_CLASS_NAME = 'scroll-row'
-
 export const GetTypesTable = observer<{
-  typeId?: string
   typeService: ITypeService
   fieldService: IFieldService
-}>(({ typeId, typeService, fieldService }) => {
-  const { types, typesList } = typeService
+}>(({ typeService, fieldService }) => {
+  const { typesList } = typeService
 
   const {
     isLoadingAllTypes,
@@ -31,26 +25,12 @@ export const GetTypesTable = observer<{
 
   const [curPage, setCurPage] = useState(1)
   const [curPageSize, setCurPageSize] = useState(25)
-  const [rowClassReady, setRowClassReady] = useState(false)
-  const router = useRouter()
 
   const { columns, rowSelection, pagination } = useTypesTable({
     typeService,
     isLoadingTypeDependencies: isLoadingAllTypes,
     fieldService,
   })
-
-  const findPageOfCurrentType = () => {
-    const currentType = types.get(typeId ?? '')
-
-    if (!currentType) {
-      return
-    }
-
-    return Math.ceil(
-      (typesList.findIndex((t) => t.id === currentType.id) + 1) / curPageSize,
-    )
-  }
 
   const handlePageChange = useCallback(
     (page: number, pageSize: number) => {
@@ -62,46 +42,12 @@ export const GetTypesTable = observer<{
   )
 
   useEffect(() => {
-    if (!typesList.length && typeId) {
-      return
-    }
-
-    let offset = (curPage - 1) * curPageSize
-
-    if (typeId) {
-      const page = findPageOfCurrentType()
-
-      if (page) {
-        handlePageChange(page, curPageSize)
-        offset = (page - 1) * curPageSize
-
-        /**
-         * Removing the current type id from the url because there is no use for it anymore
-         */
-        router.push(PageType.Type).catch((e) => console.error(e))
-      }
-    }
-
+    const offset = (curPage - 1) * curPageSize
     void getBaseTypes({
       offset,
       limit: curPageSize,
     })
   }, [curPage, curPageSize, getBaseTypes])
-
-  /**
-   * Scroll to the current type to make sure it is visible
-   */
-  useEffect(() => {
-    const scrollRow = document.querySelector(`.${SCROLL_ROW_CLASS_NAME}`)
-
-    if (scrollRow) {
-      scrollIntoView(scrollRow as HTMLElement, {
-        align: {
-          top: 0,
-        },
-      })
-    }
-  }, [rowClassReady])
 
   return (
     <Table<IAnyType>
@@ -113,7 +59,6 @@ export const GetTypesTable = observer<{
             await getTypeDescendants(record.id)
           }
         },
-        defaultExpandedRowKeys: [typeId ?? ''],
         expandedRowRender: (type) =>
           isLoadingAllTypes || isLoadingTypeDescendants ? (
             <Spin />
@@ -131,15 +76,6 @@ export const GetTypesTable = observer<{
         current: curPage,
         pageSize: curPageSize,
         onChange: handlePageChange,
-      }}
-      rowClassName={(record) => {
-        if (record.id === typeId) {
-          setRowClassReady(true)
-
-          return SCROLL_ROW_CLASS_NAME
-        }
-
-        return ''
       }}
       rowKey={(type) => type.id}
       rowSelection={rowSelection}

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/GetTypesTable.tsx
@@ -19,6 +19,7 @@ export const GetTypesTable = observer<{
   const {
     isLoadingAllTypes,
     getBaseTypes,
+    fetchedBaseTypes,
     isLoadingTypeDescendants,
     getTypeDescendants,
   } = useTypesTableData(typeService)
@@ -49,10 +50,17 @@ export const GetTypesTable = observer<{
     })
   }, [curPage, curPageSize, getBaseTypes])
 
+  const curPageDataStartIndex = typesList.findIndex(
+    (t) => t.id === fetchedBaseTypes?.[0]?.id,
+  )
+
   return (
     <Table<IAnyType>
       columns={columns}
-      dataSource={typesList}
+      dataSource={typesList.slice(
+        curPageDataStartIndex >= 0 ? curPageDataStartIndex : 0,
+        (curPageDataStartIndex >= 0 ? curPageDataStartIndex : 0) + curPageSize,
+      )}
       expandable={{
         onExpand: async (expanded, record) => {
           if (expanded) {

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/getTypeHooks.ts
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/getTypeHooks.ts
@@ -1,9 +1,0 @@
-import { useRouter } from 'next/router'
-
-export const useCurrentTypeId = () => {
-  const {
-    query: { typeId },
-  } = useRouter()
-
-  return typeId as string
-}

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/index.ts
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/index.ts
@@ -1,4 +1,3 @@
 export * from './getInterfaceHooks'
-export * from './getTypeHooks'
 export * from './GetTypesTable'
 export * from './tables/TypeDetailsTable'

--- a/libs/frontend/domain/type/src/use-cases/types/get-types/useTypesTableData.ts
+++ b/libs/frontend/domain/type/src/use-cases/types/get-types/useTypesTableData.ts
@@ -13,12 +13,14 @@ export const useTypesTableData = (typeService: ITypeService) => {
     options: Parameters<typeof typeService.getBaseTypes>[0],
   ) => {
     const baseTypeIds = await typeService.getBaseTypes(options)
-    await typeService.getAll({ id_IN: baseTypeIds })
+
+    return await typeService.getAll({ id_IN: baseTypeIds })
   }
 
-  const [{ loading: isLoadingAllTypes }, getBaseTypes] = useAsyncFn(
-    setupCurrentPageTypes,
-  )
+  const [
+    { loading: isLoadingAllTypes, value: fetchedBaseTypes },
+    getBaseTypes,
+  ] = useAsyncFn(setupCurrentPageTypes)
 
   const [{ loading: isLoadingTypeDescendants }, getTypeDescendants] =
     useAsyncFn(async (id: string) => {
@@ -28,6 +30,7 @@ export const useTypesTableData = (typeService: ITypeService) => {
   return {
     isLoadingAllTypes,
     getBaseTypes,
+    fetchedBaseTypes,
     isLoadingTypeDescendants,
     getTypeDescendants,
   }


### PR DESCRIPTION
## Description (Optional)

In addition to fixing non-adjacent pages data, this PR removes the support for navigating to the selected id in /types url query.

## Related Issue(s)

Fixes #2079
