### PR TITLE
refactor: dont wrap the element with DraggableElementWrapper if not on builder

### DIFF
--- a/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/renderer.model.interface.ts
@@ -13,6 +13,7 @@ export interface IRenderer {
   appStore: Ref<IStore>
   pageTree: Nullable<Ref<IElementTree>>
   debugMode: boolean
+  isBuilder: boolean
   state: IProp
   renderIntermediateElement(
     element: IElement,

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -11,10 +11,10 @@ import React, { useCallback, useContext, useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { GlobalPropsContext } from '../props/globalPropsContext'
 import { mapOutput } from '../utils/renderOutputUtils'
-import { DraggableElementWrapper } from './DraggableElementWrapper'
 import {
   extractValidProps,
   getReactComponent,
+  makeDraggableElement,
   withMaybeGlobalPropsProvider,
 } from './wrapper.utils'
 
@@ -95,6 +95,14 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       return withMaybeProviders(IntermediateChildren)
     })
 
+    // wrap to div if not draggable so that its view is the same as in builder mode
+    const WrappedElement = renderService.isBuilder
+      ? makeDraggableElement({ children: Rendered, element })
+      : React.createElement('div', {
+          children: Rendered,
+          style: { position: 'relative' },
+        })
+
     return React.createElement(
       ErrorBoundary,
       {
@@ -107,10 +115,7 @@ export const ElementWrapper = observer<ElementWrapperProps>(
           element.setRenderingError(null)
         },
       },
-      React.createElement(DraggableElementWrapper, {
-        children: Rendered,
-        element,
-      }),
+      WrappedElement,
     )
   },
 )

--- a/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
+++ b/libs/frontend/domain/renderer/src/element/wrapper.utils.ts
@@ -8,6 +8,8 @@ import type { ReactElement } from 'react'
 import React, { Fragment } from 'react'
 import { getAtom } from '../atoms'
 import { withGlobalPropsProvider } from '../props/globalPropsContext'
+import type { DraggableElementProps } from './DraggableElement'
+import { DraggableElementWrapper } from './DraggableElementWrapper'
 
 /**
  * Fragments can only have the `key` prop
@@ -47,3 +49,13 @@ export const makeCustomTextContainer = (customText: string) =>
   })
 
 export const noWrapper = () => (children: ReactElement) => children
+
+export const makeDraggableElement = ({
+  children,
+  element,
+}: DraggableElementProps) => {
+  return React.createElement(DraggableElementWrapper, {
+    children,
+    element,
+  })
+}

--- a/libs/frontend/domain/renderer/src/renderer.model.ts
+++ b/libs/frontend/domain/renderer/src/renderer.model.ts
@@ -114,6 +114,7 @@ const init = async ({
       // pass
       global: frozen(isBuilder ? builderGlobals : {}),
     }),
+    isBuilder,
   })
 }
 
@@ -160,6 +161,11 @@ export class Renderer
       debugMode: prop(false).withSetter(),
 
       renderComponentMeta: prop<IPropData>(() => ({})).withSetter(),
+
+      /**
+       * Used for making the element draggable if true (e.g. in builder page)
+       */
+      isBuilder: prop(false),
     },
     {
       toSnapshotProcessor(sn, modelInstance) {


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description (Optional)

<!-- This is a short description on the Pull Request -->
- add the `isBuilder` to the `Renderer` model so it can be used to conditionally wrap the element with `DraggableElementWrapper` if `isBuilder` is `true`
- the element will not be wrapped with `DraggableElementWrapper` if `isBuilder` is false (e.g. when in `.../pages/{pageId})` for view mode)

**view mode:**
![Screenshot from 2023-01-09 21-04-16](https://user-images.githubusercontent.com/27695022/211319244-26310956-f489-48f8-8fa4-69ef42cab85b.png)

**builder mode:**
![Screenshot from 2023-01-09 21-05-48](https://user-images.githubusercontent.com/27695022/211319344-9e909894-b16f-4580-906e-b24c287da87b.png)


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2094 
