### PR TITLE
Add fields modifying modals to atoms page

### DIFF
--- a/apps/builder/pages/atoms/index.tsx
+++ b/apps/builder/pages/atoms/index.tsx
@@ -13,6 +13,11 @@ import {
   htmlAtoms,
   muiAtoms,
 } from '@codelab/frontend/domain/renderer'
+import {
+  CreateFieldModal,
+  DeleteFieldModal,
+  UpdateFieldModal,
+} from '@codelab/frontend/domain/type'
 import { useStore } from '@codelab/frontend/presenter/container'
 import {
   adminMenuItems,
@@ -77,12 +82,23 @@ const AtomsPage: CodelabPage<DashboardTemplateProps> = observer(() => {
         tagService={store.tagService}
       />
       <DeleteAtomsModal atomService={store.atomService} />
+      <CreateFieldModal
+        fieldService={store.fieldService}
+        typeService={store.typeService}
+      />
+      <UpdateFieldModal
+        fieldService={store.fieldService}
+        typeService={store.typeService}
+      />
+      <DeleteFieldModal fieldService={store.fieldService} />
       <ContentSection>
         <GetAtomsTable
           atomService={store.atomService}
+          fieldService={store.fieldService}
           getAtomLibrary={getAtomLibrary}
           page={page ? parseInt(page as string) : undefined}
           pageSize={pageSize ? parseInt(pageSize as string) : undefined}
+          typeService={store.typeService}
         />
       </ContentSection>
     </>

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/GetAtomsTable.tsx
@@ -1,4 +1,8 @@
-import type { IAtomService } from '@codelab/frontend/abstract/core'
+import type {
+  IAtomService,
+  IFieldService,
+  ITypeService,
+} from '@codelab/frontend/abstract/core'
 import { PageType } from '@codelab/frontend/abstract/types'
 import { Table } from 'antd'
 import { observer } from 'mobx-react-lite'
@@ -13,20 +17,29 @@ const DEFAULT_CUR_PAGE = 1
 
 interface GetAtomsTableProps {
   atomService: IAtomService
+  typeService: ITypeService
+  fieldService: IFieldService
   getAtomLibrary: (atomType: string) => AtomLibrary
   page?: number
   pageSize?: number
 }
 
 export const GetAtomsTable = observer<GetAtomsTableProps>(
-  ({ atomService, getAtomLibrary, page, pageSize }) => {
+  ({
+    atomService,
+    typeService,
+    fieldService,
+    getAtomLibrary,
+    page,
+    pageSize,
+  }) => {
     const { atomsList } = atomService
     const router = useRouter()
     const curPage = page ?? DEFAULT_CUR_PAGE
     const curPageSize = pageSize ?? DEFAULT_PAGE_SIZE
 
     const { columns, rowSelection, pagination, atomWhere, atomOptions } =
-      useAtomTable(atomService)
+      useAtomTable({ atomService, typeService, fieldService })
 
     const { value: latestFetchedAtoms, loading } = useAsync(async () => {
       return await atomService.getAll(atomWhere, atomOptions)

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/PropsColumn.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/PropsColumn.tsx
@@ -1,19 +1,95 @@
-import { PageType } from '@codelab/frontend/abstract/types'
-import Link from 'next/link'
-import React from 'react'
-import tw from 'twin.macro'
-import type { AtomRecordProps } from './types'
+import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons'
+import type { IAnyType, IField } from '@codelab/frontend/abstract/core'
+import type { InterfaceType } from '@codelab/frontend/domain/type'
+import { fieldRef, typeRef } from '@codelab/frontend/domain/type'
+import { Spinner } from '@codelab/frontend/view/components'
+import { Button, Col, Dropdown, Menu, Row } from 'antd'
+import { observer } from 'mobx-react-lite'
+import React, { useEffect } from 'react'
+import { useAsyncFn } from 'react-use'
+import type { PropsColumnProps } from './types'
 
-export const PropsColumn = ({ atom }: AtomRecordProps) => {
-  return (
-    <Link
-      css={tw`text-blue-700`}
-      href={{
-        pathname: PageType.Type,
-        query: { typeId: atom.apiId },
-      }}
-    >
-      View API
-    </Link>
-  )
-}
+export const PropsColumn = observer<PropsColumnProps>(
+  ({ atom, fieldService, typeService }) => {
+    const [{ value: interfaceType, loading }, getInterfaceAndDescendants] =
+      useAsyncFn(
+        () => typeService.getInterfaceAndDescendants(atom.apiId),
+        [atom.apiId],
+      )
+
+    const onEdit = (field: IField<IAnyType>) => {
+      fieldService.updateModal.open(fieldRef(field.id))
+    }
+
+    const onDelete = (field: IField<IAnyType>) => {
+      fieldService.deleteModal.open(fieldRef(field.id))
+    }
+
+    useEffect(() => {
+      console.log('the interface has been updated!')
+    }, [interfaceType])
+
+    const editMenuItems = interfaceType?.fields.map((field) => {
+      return {
+        label: field.name,
+        key: field.key,
+        onClick: () => onEdit(field),
+      }
+    })
+
+    const deleteMenuItems = interfaceType?.fields.map((field) => {
+      return {
+        label: field.name,
+        key: field.key,
+        onClick: () => onDelete(field),
+      }
+    })
+
+    return (
+      <Row gutter={[16, 16]} justify="center">
+        <Spinner isLoading={loading}>
+          {interfaceType ? (
+            <>
+              <Col>
+                <Button
+                  onClick={() =>
+                    fieldService.createModal.open(
+                      typeRef<InterfaceType>(interfaceType.id),
+                    )
+                  }
+                >
+                  <PlusOutlined />
+                </Button>
+              </Col>
+              {Boolean(interfaceType.fields.length) && (
+                <>
+                  <Col>
+                    <Dropdown.Button overlay={<Menu items={editMenuItems} />}>
+                      <EditOutlined />
+                    </Dropdown.Button>
+                  </Col>
+                  <Col>
+                    <Dropdown.Button
+                      danger
+                      overlay={<Menu items={deleteMenuItems} />}
+                    >
+                      <DeleteOutlined />
+                    </Dropdown.Button>
+                  </Col>
+                </>
+              )}
+            </>
+          ) : (
+            <Button
+              onClick={() => {
+                void getInterfaceAndDescendants()
+              }}
+            >
+              Edit API
+            </Button>
+          )}
+        </Spinner>
+      </Row>
+    )
+  },
+)

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/types.ts
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/columns/types.ts
@@ -1,8 +1,10 @@
 import type {
   IAtomDTO,
   IAtomService,
+  IFieldService,
   IInterfaceTypeRef,
   ITag,
+  ITypeService,
 } from '@codelab/frontend/abstract/core'
 import type { IAtomType } from '@codelab/shared/abstract/core'
 
@@ -23,6 +25,11 @@ export interface AtomRecord {
 
 export type ActionColumnProps = {
   atomService: IAtomService
+} & AtomRecordProps
+
+export type PropsColumnProps = {
+  fieldService: IFieldService
+  typeService: ITypeService
 } & AtomRecordProps
 
 /**

--- a/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
+++ b/libs/frontend/domain/atom/src/use-cases/get-atoms/useAtomTable.tsx
@@ -1,4 +1,8 @@
-import type { IAtomService } from '@codelab/frontend/abstract/core'
+import type {
+  IAtomService,
+  IFieldService,
+  ITypeService,
+} from '@codelab/frontend/abstract/core'
 import { useColumnSearchProps } from '@codelab/frontend/view/components'
 import { headerCellProps } from '@codelab/frontend/view/style'
 import type { AtomOptions, AtomWhere } from '@codelab/shared/abstract/codegen'
@@ -26,7 +30,15 @@ const onLibraryFilter = (
   return list.some((x) => x.startsWith(search))
 }
 
-export const useAtomTable = (atomService: IAtomService) => {
+export const useAtomTable = ({
+  atomService,
+  typeService,
+  fieldService,
+}: {
+  atomService: IAtomService
+  typeService: ITypeService
+  fieldService: IFieldService
+}) => {
   const [atomWhere, setAtomWhere] = useState<Maybe<AtomWhere>>(undefined)
 
   const [atomOptions, setAtomOptions] = useState<AtomOptions>({
@@ -98,9 +110,15 @@ export const useAtomTable = (atomService: IAtomService) => {
       title: 'Props API',
       dataIndex: 'props',
       key: 'props',
-      width: 100,
+      width: 300,
       onHeaderCell: headerCellProps,
-      render: (_, atom) => <PropsColumn atom={atom} />,
+      render: (_, atom) => (
+        <PropsColumn
+          atom={atom}
+          fieldService={fieldService}
+          typeService={typeService}
+        />
+      ),
     },
     {
       title: 'Action',


### PR DESCRIPTION
## Description

Here I used the same buttons used in the Builder. however, I've hidden them under `Edit API` button so we load the interfaces on demand instead of loading all of them with the initial page load.

## Video or Image

https://user-images.githubusercontent.com/51242349/211617103-f33564e1-630a-44c9-80cc-0253b4cfbf81.mp4

## Related Issue(s)

Fixes #2153 
