### PR TITLE
fix: cannot dnd atom to the builder if it is the first element

### DIFF
--- a/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
@@ -38,6 +38,7 @@ export enum BuilderDndType {
 export enum DragPosition {
   Before = 'Before',
   After = 'After',
+  Inside = 'Inside',
 }
 
 export const defaultBuilderWidthBreakPoints: Record<

--- a/libs/frontend/abstract/types/src/utils.tsx
+++ b/libs/frontend/abstract/types/src/utils.tsx
@@ -1,1 +1,4 @@
 export type Callback<TIn, TOut = unknown> = (param: TIn) => TOut
+export type WithStyleProp<T extends object> = T & {
+  style?: Record<string, string | number>
+}

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -105,7 +105,10 @@ export const Builder = observer<BuilderProps>(
           onMouseLeave={handleMouseLeave}
           onMouseOver={handleMouseOver}
         >
-          <Renderer renderRoot={rendererProps.renderRoot} />
+          <Renderer
+            elementId={elementTree.root?.id}
+            renderRoot={rendererProps.renderRoot}
+          />
 
           {/* <BuilderHoverOverlay /> */}
           {/* <BuilderClickOverlay /> */}

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -56,6 +56,11 @@ export const Builder = observer<BuilderProps>(
     selectedBuilderWidth: selectedMainContentWidth,
     setCurrentBuilderWidth,
   }) => {
+    // to render the body of the app, the root is required
+    if (!elementTree.root) {
+      return null
+    }
+
     const { handleMouseOver, handleMouseLeave } = useBuilderHoverHandlers({
       currentDragData,
       set_hoveredNode,
@@ -67,11 +72,8 @@ export const Builder = observer<BuilderProps>(
       setCurrentBuilderWidth,
     })
 
-    // by our current IElement, root can be undefined
-    // useDroppable does not accept an undefined id
-    // since this is the root element, id should be defined
     const { setNodeRef, isOver, over } = useDroppable({
-      id: elementTree.root?.id as string,
+      id: elementTree.root.id,
     })
 
     useBuilderHotkeys({
@@ -91,8 +93,8 @@ export const Builder = observer<BuilderProps>(
 
     const rootStyle = isOver
       ? makeDropIndicatorStyle(DragPosition.Inside, {
-        backgroundColor: 'rgba(0, 255, 255, 0.2)',
-      })
+          backgroundColor: 'rgba(0, 255, 255, 0.2)',
+        })
       : {}
 
     return (

--- a/libs/frontend/domain/renderer/src/Renderer.tsx
+++ b/libs/frontend/domain/renderer/src/Renderer.tsx
@@ -1,9 +1,6 @@
 import type { IRenderer } from '@codelab/frontend/abstract/core'
-import {
-  DragPosition,
-  ROOT_RENDER_CONTAINER_ID,
-} from '@codelab/frontend/abstract/core'
-import { useDroppable } from '@dnd-kit/core'
+import { ROOT_RENDER_CONTAINER_ID } from '@codelab/frontend/abstract/core'
+import type { WithStyleProp } from '@codelab/frontend/abstract/types'
 import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
 import ErrorBoundary from 'antd/lib/alert/ErrorBoundary'
@@ -40,27 +37,15 @@ const emotionCache = createCache({
   prepend: false,
 })
 
-export const Renderer = observer<RendererRoot & { elementId?: string }>(
-  ({ renderRoot, elementId }) => {
-    const { setNodeRef, isOver, over } = useDroppable({
-      id: elementId!,
-      disabled: !elementId,
-    })
-
-    if (isOver && over) {
-      over.data.current = {
-        ...over.data.current,
-        dragPosition: DragPosition.Inside,
-      }
-    }
-
+export const Renderer = observer<WithStyleProp<RendererRoot>, HTMLDivElement>(
+  ({ renderRoot, style = {} }, ref) => {
     return (
       <ErrorBoundary>
         <CacheProvider value={emotionCache}>
           <div
             id={ROOT_RENDER_CONTAINER_ID}
-            ref={setNodeRef}
-            style={{ minHeight: '100%', transform: 'translatex(0)' }}
+            ref={ref}
+            style={{ minHeight: '100%', transform: 'translatex(0)', ...style }}
           >
             {renderRoot()}
           </div>
@@ -68,6 +53,7 @@ export const Renderer = observer<RendererRoot & { elementId?: string }>(
       </ErrorBoundary>
     )
   },
+  { forwardRef: true },
 )
 
 Renderer.displayName = 'Renderer'

--- a/libs/frontend/domain/renderer/src/Renderer.tsx
+++ b/libs/frontend/domain/renderer/src/Renderer.tsx
@@ -1,5 +1,9 @@
 import type { IRenderer } from '@codelab/frontend/abstract/core'
-import { ROOT_RENDER_CONTAINER_ID } from '@codelab/frontend/abstract/core'
+import {
+  DragPosition,
+  ROOT_RENDER_CONTAINER_ID,
+} from '@codelab/frontend/abstract/core'
+import { useDroppable } from '@dnd-kit/core'
 import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
 import ErrorBoundary from 'antd/lib/alert/ErrorBoundary'
@@ -36,19 +40,34 @@ const emotionCache = createCache({
   prepend: false,
 })
 
-export const Renderer = observer<RendererRoot>(({ renderRoot }) => {
-  return (
-    <ErrorBoundary>
-      <CacheProvider value={emotionCache}>
-        <div
-          id={ROOT_RENDER_CONTAINER_ID}
-          style={{ minHeight: '100%', transform: 'translatex(0)' }}
-        >
-          {renderRoot()}
-        </div>
-      </CacheProvider>
-    </ErrorBoundary>
-  )
-})
+export const Renderer = observer<RendererRoot & { elementId?: string }>(
+  ({ renderRoot, elementId }) => {
+    const { setNodeRef, isOver, over } = useDroppable({
+      id: elementId!,
+      disabled: !elementId,
+    })
+
+    if (isOver && over) {
+      over.data.current = {
+        ...over.data.current,
+        dragPosition: DragPosition.Inside,
+      }
+    }
+
+    return (
+      <ErrorBoundary>
+        <CacheProvider value={emotionCache}>
+          <div
+            id={ROOT_RENDER_CONTAINER_ID}
+            ref={setNodeRef}
+            style={{ minHeight: '100%', transform: 'translatex(0)' }}
+          >
+            {renderRoot()}
+          </div>
+        </CacheProvider>
+      </ErrorBoundary>
+    )
+  },
+)
 
 Renderer.displayName = 'Renderer'

--- a/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
+++ b/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
@@ -3,10 +3,11 @@ import type {
   IElement,
   IPropData,
 } from '@codelab/frontend/abstract/core'
-import { BuilderDndType, DragPosition } from '@codelab/frontend/abstract/core'
+import { BuilderDndType } from '@codelab/frontend/abstract/core'
 import type { Nullable } from '@codelab/shared/abstract/types'
 import { useDraggable, useDroppable } from '@dnd-kit/core'
 import React, { useEffect } from 'react'
+import { makeDropIndicatorStyle } from '../utils'
 import { calcDragPosition, useElementLayout } from './draggableElement.util'
 import { ElementDragOverlay } from './ElementDragOverlay'
 
@@ -80,26 +81,15 @@ export const DraggableElement = ({
     droppableNodeRef.current = ref
   }
 
-  const indicatorStyle: Record<string, string | number> = { zIndex: 100 }
-
-  switch (dragPosition) {
-    case DragPosition.After:
-      indicatorStyle['boxShadow'] = '0px 5px 0px cyan'
-      break
-    case DragPosition.Before:
-      indicatorStyle['boxShadow'] = '0px -5px 0px cyan'
-      break
-    case DragPosition.Inside:
-      indicatorStyle['boxShadow'] = '0px 0px 0px 5px cyan'
-      break
-    default:
-      break
-  }
+  const indicatorStyle =
+    isOver && dragPosition
+      ? { style: makeDropIndicatorStyle(dragPosition) }
+      : {}
 
   const renderedChildren = makeRenderedElements({
     ...draggableAttrs,
     ...draggableListeners,
-    ...(isOver ? { style: indicatorStyle } : {}),
+    ...indicatorStyle,
   })
 
   return Array.isArray(renderedChildren) ? (

--- a/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
+++ b/libs/frontend/domain/renderer/src/element/DraggableElement.tsx
@@ -80,11 +80,20 @@ export const DraggableElement = ({
     droppableNodeRef.current = ref
   }
 
-  const indicatorStyle = {
-    boxShadow:
-      dragPosition === DragPosition.After
-        ? '0px 5px 0px cyan'
-        : '0px -5px 0px cyan',
+  const indicatorStyle: Record<string, string | number> = { zIndex: 100 }
+
+  switch (dragPosition) {
+    case DragPosition.After:
+      indicatorStyle['boxShadow'] = '0px 5px 0px cyan'
+      break
+    case DragPosition.Before:
+      indicatorStyle['boxShadow'] = '0px -5px 0px cyan'
+      break
+    case DragPosition.Inside:
+      indicatorStyle['boxShadow'] = '0px 0px 0px 5px cyan'
+      break
+    default:
+      break
   }
 
   const renderedChildren = makeRenderedElements({

--- a/libs/frontend/domain/renderer/src/element/draggableElement.util.ts
+++ b/libs/frontend/domain/renderer/src/element/draggableElement.util.ts
@@ -54,9 +54,13 @@ export const calcDragPosition = (
   dragYCoordinate: number,
   draggedOnElHeight: number,
 ): Maybe<DragPosition> => {
-  if (Math.abs(dragYCoordinate) < draggedOnElHeight / 2) {
+  if (Math.abs(dragYCoordinate) < draggedOnElHeight / 3) {
     return DragPosition.Before
   }
 
-  return DragPosition.After
+  if (Math.abs(dragYCoordinate) > draggedOnElHeight * (2 / 3)) {
+    return DragPosition.After
+  }
+
+  return DragPosition.Inside
 }

--- a/libs/frontend/domain/renderer/src/utils/index.ts
+++ b/libs/frontend/domain/renderer/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './makeDropIndicatorStyle'
 export * from './queryRenderedElementById'

--- a/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
+++ b/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
@@ -1,0 +1,32 @@
+import { DragPosition } from '@codelab/frontend/abstract/core'
+
+type Style = Record<string, string | number>
+
+/**
+ * creates a style object that can be used to add styling to the droppable element
+ * @param dragPosition position where the dragged element will be dropped
+ * @param customStyles custom styles to be shared on all positions
+ * @returns object containing css styling values
+ */
+export const makeDropIndicatorStyle = (
+  dragPosition: DragPosition,
+  customStyles?: Style,
+) => {
+  const indicatorStyle: Style = { ...customStyles }
+
+  switch (dragPosition) {
+    case DragPosition.After:
+      indicatorStyle['boxShadow'] = '0px 5px 0px cyan'
+      break
+    case DragPosition.Before:
+      indicatorStyle['boxShadow'] = '0px -5px 0px cyan'
+      break
+    case DragPosition.Inside:
+      indicatorStyle['boxShadow'] = '0px 0px 0px 5px cyan'
+      break
+    default:
+      break
+  }
+
+  return indicatorStyle
+}


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
The root element needs to be droppable so that we can drop a draggable element into it.

The logic for creating a first child should also be fixed.

## Video or Image

<!-- Add video or image showing how the new feature works -->


https://user-images.githubusercontent.com/27695022/212038489-1736bbae-554e-4d5a-921d-d1e03921a881.mp4


https://user-images.githubusercontent.com/27695022/211850769-23c0e841-638d-410c-9079-4f18001878a3.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2106 
