### PR TITLE
Builder size selector enhancements

### DIFF
--- a/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.interface.ts
@@ -17,6 +17,19 @@ export interface BuilderDropData {
   dragPosition?: DragPosition
 }
 
+export interface BuilderWidth {
+  min: number
+  max: number
+  default: number
+}
+
+export const enum BuilderWidthBreakPoints {
+  Mobile = 'mobile',
+  MobileVertical = 'mobile-vertical',
+  TabletHorizontal = 'tablet-horizontal',
+  Desktop = 'desktop',
+}
+
 export enum BuilderDndType {
   CreateElement = 'CreateElement',
   MoveElement = 'MoveElement',
@@ -25,6 +38,25 @@ export enum BuilderDndType {
 export enum DragPosition {
   Before = 'Before',
   After = 'After',
+}
+
+export const defaultBuilderWidthBreakPoints: Record<
+  BuilderWidthBreakPoints,
+  BuilderWidth
+> = {
+  [BuilderWidthBreakPoints.Mobile]: { min: 240, max: 479, default: 320 },
+  [BuilderWidthBreakPoints.MobileVertical]: {
+    min: 480,
+    max: 767,
+    default: 568,
+  },
+  [BuilderWidthBreakPoints.TabletHorizontal]: {
+    min: 768,
+    max: 991,
+    default: 768,
+  },
+  // -1 means automatically set the value for this field to the max available space
+  [BuilderWidthBreakPoints.Desktop]: { min: 992, max: -1, default: -1 },
 }
 
 /**

--- a/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
+++ b/libs/frontend/abstract/core/src/domain/builder/builder.service.interface.ts
@@ -4,7 +4,7 @@ import type { IAtom } from '../atom'
 import type { IComponent } from '../component'
 import type { IElementTree } from '../element'
 import type { RendererTab } from '../render'
-import type { BuilderDragData } from './builder.interface'
+import type { BuilderDragData, BuilderWidth } from './builder.interface'
 import type { INode } from './node.interface'
 
 // TBC: | IComponent
@@ -22,9 +22,15 @@ export interface IBuilderService {
   _hoveredNode: Nullable<Ref<INode>>
   selectedNode: Nullable<INode>
   hoveredNode: Nullable<INode>
-  mainContentWidth: Nullable<number>
-  mainResizingContentWidth: Nullable<number>
-  resizingMainContent: boolean
+  /**
+   * The difference between current and selected builderWidth is that
+   * - currentBuilderWidth is changed by useBuilderResize
+   * - selectedBuilderWidth is changed by PageDetailHeader and
+   * is being listened to by useBuilderResize
+   */
+  currentBuilderWidth: BuilderWidth
+  selectedBuilderWidth: BuilderWidth
+  builderContainerWidth: number
   currentDragData: Nullable<Frozen<BuilderDragData>>
   activeElementTree: Maybe<IElementTree>
 
@@ -45,9 +51,9 @@ export interface IBuilderService {
   // setSelectedTreeNode(node: IBuilderDataNode | null): void
   set_hoveredNode(element: Nullable<Ref<INode>>): void
   set_selectedNode(node: Nullable<Ref<INode>>): void
-  setMainContentWidth(width: Nullable<number>): void
-  setMainResizingContentWidth(width: Nullable<number>): void
-  setResizingMainContent(data: boolean): void
+  setCurrentBuilderWidth(width: Nullable<BuilderWidth>): void
+  setSelectedBuilderWidth(width: Nullable<BuilderWidth>): void
+  setBuilderContainerWidth(width: number): void
 
   setActiveTree(tab: RendererTab): void
   setCurrentDragData(data: Nullable<Frozen<BuilderDragData>>): void

--- a/libs/frontend/domain/builder/src/sections/content/BaseBuilder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/BaseBuilder.tsx
@@ -4,8 +4,9 @@ import type {
   IElementTree,
   IRenderer,
 } from '@codelab/frontend/abstract/core'
+import { defaultBuilderWidthBreakPoints } from '@codelab/frontend/abstract/core'
 import { observer } from 'mobx-react-lite'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Builder } from './Builder'
 
 export interface BaseBuilderProps {
@@ -31,34 +32,29 @@ export const BaseBuilder = observer<BaseBuilderProps>(
       [renderer],
     )
 
-    const setMainContentWidth = useMemo(
-      () => builderService.setMainContentWidth.bind(builderService),
+    const setCurrentBuilderWidth = useMemo(
+      () => builderService.setCurrentBuilderWidth.bind(builderService),
       [builderService],
     )
 
-    const setMainResizingContentWidth = useMemo(
-      () => builderService.setMainResizingContentWidth.bind(builderService),
-      [builderService],
-    )
-
-    const setResizingMainContent = useMemo(
-      () => builderService.setResizingMainContent.bind(builderService),
-      [builderService],
-    )
+    useEffect(() => {
+      builderService.setBuilderContainerWidth(builderTabsWidth ?? 0)
+      builderService.setSelectedBuilderWidth(
+        defaultBuilderWidthBreakPoints.desktop,
+      )
+    }, [builderTabsWidth, builderService])
 
     return (
       <Builder
-        builderTabsWidth={builderTabsWidth}
+        currentBuilderWidth={builderService.currentBuilderWidth}
         currentDragData={builderService.currentDragData}
         deleteModal={elementService.deleteModal}
         elementTree={elementTree}
         key={renderer.pageTree?.current.root?.id}
-        mainContentWidth={builderService.mainContentWidth}
         rendererProps={rendererProps}
+        selectedBuilderWidth={builderService.selectedBuilderWidth}
         selectedNode={builderService.selectedNode}
-        setMainContentWidth={setMainContentWidth}
-        setMainResizingContentWidth={setMainResizingContentWidth}
-        setResizingMainContent={setResizingMainContent}
+        setCurrentBuilderWidth={setCurrentBuilderWidth}
         set_hoveredNode={builderService.set_hoveredNode.bind(builderService)}
         set_selectedNode={builderService.set_selectedNode.bind(builderService)}
       />

--- a/libs/frontend/domain/builder/src/sections/content/Builder.tsx
+++ b/libs/frontend/domain/builder/src/sections/content/Builder.tsx
@@ -13,7 +13,7 @@ import { Renderer } from '@codelab/frontend/domain/renderer'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { observer } from 'mobx-react-lite'
-import React, { useEffect } from 'react'
+import React from 'react'
 import tw from 'twin.macro'
 import { useBuilderHotkeys, useBuilderHoverHandlers } from '../../hooks'
 import { useBuilderResize } from '../../hooks/useBuilderResize'
@@ -21,17 +21,15 @@ import { useBuilderRootClickHandler } from '../../hooks/useBuilderRootClickHandl
 
 type BuilderProps = {
   elementTree: IElementTree
-  builderTabsWidth?: number
 } & Pick<
   IBuilderService,
   | 'set_hoveredNode'
   | 'currentDragData'
   | 'selectedNode'
   | 'set_selectedNode'
-  | 'mainContentWidth'
-  | 'setMainContentWidth'
-  | 'setMainResizingContentWidth'
-  | 'setResizingMainContent'
+  | 'currentBuilderWidth'
+  | 'selectedBuilderWidth'
+  | 'setCurrentBuilderWidth'
 > &
   Pick<IElementService, 'deleteModal'> & {
     rendererProps: RendererRoot
@@ -49,11 +47,9 @@ export const Builder = observer<BuilderProps>(
     deleteModal,
     set_selectedNode,
     rendererProps,
-    mainContentWidth,
-    setMainContentWidth,
-    setMainResizingContentWidth,
-    setResizingMainContent,
-    builderTabsWidth,
+    currentBuilderWidth: mainContentWidth,
+    selectedBuilderWidth: selectedMainContentWidth,
+    setCurrentBuilderWidth,
   }) => {
     const { handleMouseOver, handleMouseLeave } = useBuilderHoverHandlers({
       currentDragData,
@@ -61,14 +57,9 @@ export const Builder = observer<BuilderProps>(
     })
 
     const builderResizable = useBuilderResize({
-      width: {
-        default: mainContentWidth ? mainContentWidth : builderTabsWidth,
-        min: 100,
-        max: builderTabsWidth,
-      },
-      setResizingMainContent,
-      setMainResizingContentWidth,
-      setMainContentWidth,
+      width: mainContentWidth,
+      selectedWidth: selectedMainContentWidth,
+      setCurrentBuilderWidth,
     })
 
     useBuilderHotkeys({
@@ -78,10 +69,6 @@ export const Builder = observer<BuilderProps>(
     })
 
     const handleContainerClick = useBuilderRootClickHandler()
-
-    useEffect(() => {
-      return setResizingMainContent(false)
-    }, [])
 
     return (
       <StyledBuilderResizeContainer

--- a/libs/frontend/domain/builder/src/store/builder.service.ts
+++ b/libs/frontend/domain/builder/src/store/builder.service.ts
@@ -4,6 +4,8 @@ import type {
   INode,
 } from '@codelab/frontend/abstract/core'
 import {
+  BuilderWidth,
+  defaultBuilderWidthBreakPoints,
   isComponent,
   isElement,
   RendererTab,
@@ -40,9 +42,13 @@ export class BuilderService
      */
     _selectedNode: prop<Nullable<Ref<INode>>>(null).withSetter(),
     _hoveredNode: prop<Nullable<Ref<INode>>>(null).withSetter(),
-    mainContentWidth: prop<Nullable<number>>(null),
-    mainResizingContentWidth: prop<Nullable<number>>(null).withSetter(),
-    resizingMainContent: prop<boolean>(false).withSetter(),
+    currentBuilderWidth: prop<BuilderWidth>(
+      () => defaultBuilderWidthBreakPoints.desktop,
+    ),
+    selectedBuilderWidth: prop<BuilderWidth>(
+      () => defaultBuilderWidthBreakPoints.desktop,
+    ),
+    builderContainerWidth: prop<number>(0).withSetter(),
     currentDragData: prop<Nullable<Frozen<BuilderDragData>>>(null).withSetter(),
     expandedPageElementTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
     expandedComponentTreeNodeIds: prop<Array<string>>(() => []).withSetter(),
@@ -221,8 +227,26 @@ export class BuilderService
   }
 
   @modelAction
-  setMainContentWidth(width: Nullable<number>) {
-    this.mainContentWidth = width
-    this.mainResizingContentWidth = width
+  setCurrentBuilderWidth(width: BuilderWidth) {
+    this.currentBuilderWidth.default = width.default
+    this.currentBuilderWidth.min = width.min
+    this.currentBuilderWidth.max = width.max
+  }
+
+  @modelAction
+  setSelectedBuilderWidth(width: BuilderWidth) {
+    // -1 max width means fill the screen, so we use the available
+    // container width as long as it's not smaller than the min
+    this.selectedBuilderWidth = {
+      default:
+        width.default < 0
+          ? Math.max(width.min, this.builderContainerWidth)
+          : width.default,
+      min: width.min,
+      max:
+        width.max < 0
+          ? Math.max(width.min, this.builderContainerWidth)
+          : width.max,
+    }
   }
 }

--- a/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
+++ b/libs/frontend/domain/page/src/view/PageDetailHeader.tsx
@@ -3,7 +3,6 @@ import {
   EyeOutlined,
   FileOutlined,
   MobileOutlined,
-  SettingOutlined,
   TabletOutlined,
   ToolOutlined,
 } from '@ant-design/icons'
@@ -11,18 +10,22 @@ import type {
   IBuilderService,
   IPageService,
 } from '@codelab/frontend/abstract/core'
+import {
+  BuilderWidthBreakPoints,
+  defaultBuilderWidthBreakPoints,
+} from '@codelab/frontend/abstract/core'
 import { PageType } from '@codelab/frontend/abstract/types'
 import {
   useCurrentAppId,
   useCurrentPageId,
 } from '@codelab/frontend/presenter/container'
-import { InputNumber, Menu } from 'antd'
+import { InputNumber, Menu, Space } from 'antd'
 import type { ItemType } from 'antd/lib/menu/hooks/useItems'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { useAsync } from 'react-use'
-import { mainContentWidthBreakPoint } from './constants'
+// import { BuilderSizeBreakpoints, mainContentWidthBreakPoint } from './constants'
 
 export type MenuItemProps = {
   hide?: boolean
@@ -52,9 +55,23 @@ export const PageDetailHeader = observer<{
     })
   }
 
+  const [selectedWidthBreakpoint, setSelectedWidthBreakpoint] = useState(
+    BuilderWidthBreakPoints.Desktop,
+  )
+
+  const handleBreakpointSelected = useCallback(
+    (breakpoint: BuilderWidthBreakPoints) => {
+      setSelectedWidthBreakpoint(breakpoint)
+      builderService?.setSelectedBuilderWidth(
+        defaultBuilderWidthBreakPoints[breakpoint],
+      )
+    },
+    [],
+  )
+
   const menuItems: Array<MenuItemProps> = [
     {
-      icon: <FileOutlined />,
+      label: <FileOutlined />,
       key: 'sub1',
       title: currentPage?.name,
       children: pagesList.map((page) => ({
@@ -73,74 +90,70 @@ export const PageDetailHeader = observer<{
       hide: false,
     },
     {
-      icon: isBuilder ? <EyeOutlined /> : <ToolOutlined />,
+      label: isBuilder ? <EyeOutlined /> : <ToolOutlined />,
       key: '1',
+      title: isBuilder ? 'Preview' : 'Builder',
       onClick: switchPreviewMode,
       style: { backgroundColor: 'initial' },
       hide: false,
     },
     {
-      icon: <MobileOutlined />,
-      key: 'mobile',
-      onClick: () => {
-        builderService?.setMainContentWidth(mainContentWidthBreakPoint.mobile)
-      },
+      label: <MobileOutlined />,
+      key: BuilderWidthBreakPoints.Mobile,
+      title: 'mobile',
+      onClick: () => handleBreakpointSelected(BuilderWidthBreakPoints.Mobile),
       style: { backgroundColor: 'initial' },
       hide: !isBuilder,
     },
     {
-      icon: <MobileOutlined rotate={-90} />,
-      key: 'mobile-vertical',
-      onClick: () => {
-        builderService?.setMainContentWidth(
-          mainContentWidthBreakPoint.mobile_vertical,
-        )
-      },
+      label: <MobileOutlined rotate={-90} />,
+      key: BuilderWidthBreakPoints.MobileVertical,
+      title: 'mobile vertical',
+      onClick: () =>
+        handleBreakpointSelected(BuilderWidthBreakPoints.MobileVertical),
       style: { backgroundColor: 'initial' },
       hide: !isBuilder,
     },
     {
-      icon: <TabletOutlined />,
-      key: 'tablet-horizontal',
-      onClick: () => {
-        builderService?.setMainContentWidth(
-          mainContentWidthBreakPoint.tablet_horizontal,
-        )
-      },
+      label: <TabletOutlined />,
+      key: BuilderWidthBreakPoints.TabletHorizontal,
+      title: 'tablet horizontal',
+      onClick: () =>
+        handleBreakpointSelected(BuilderWidthBreakPoints.TabletHorizontal),
       style: { backgroundColor: 'initial' },
       hide: !isBuilder,
     },
     {
-      icon: <DesktopOutlined />,
-      key: 'desktop',
-      onClick: () => {
-        builderService?.setMainContentWidth(null)
-      },
+      label: <DesktopOutlined />,
+      key: BuilderWidthBreakPoints.Desktop,
+      title: 'desktop',
+      onClick: () => handleBreakpointSelected(BuilderWidthBreakPoints.Desktop),
       style: { backgroundColor: 'initial' },
       hide: !isBuilder,
     },
     {
-      icon: <SettingOutlined />,
-      key: 'sub2',
-      children: [
-        {
-          key: 'custom-width',
-          disabled: true,
-          icon: (
-            <InputNumber
-              controls={false}
-              min={100}
-              onBlur={(e) => {
-                builderService?.setMainContentWidth(Number(e.target.value))
-              }}
-              value={builderService?.mainResizingContentWidth ?? ''}
-            />
-          ),
-          label: 'px',
-        },
-      ],
+      label: (
+        <Space direction="horizontal" size="small">
+          <InputNumber
+            controls={false}
+            max={builderService?.selectedBuilderWidth.max}
+            min={builderService?.selectedBuilderWidth.min}
+            onChange={(value) =>
+              builderService?.setSelectedBuilderWidth({
+                ...builderService.selectedBuilderWidth,
+                default: Number(value),
+              })
+            }
+            size="small"
+            value={builderService?.currentBuilderWidth.default ?? ''}
+          />
+          <span>px</span>
+        </Space>
+      ),
+      key: 'custom',
+      title: 'custom size',
       style: { backgroundColor: 'initial' },
-      hide: !builderService?.resizingMainContent,
+      hide: !isBuilder,
     },
   ]
 
@@ -154,6 +167,7 @@ export const PageDetailHeader = observer<{
         }))}
       mode="horizontal"
       selectable={false}
+      selectedKeys={[selectedWidthBreakpoint]}
       theme="light"
       triggerSubMenuAction="click"
     />

--- a/libs/frontend/domain/page/src/view/constants.ts
+++ b/libs/frontend/domain/page/src/view/constants.ts
@@ -1,5 +1,0 @@
-export const mainContentWidthBreakPoint = {
-  mobile: 320,
-  mobile_vertical: 568,
-  tablet_horizontal: 768,
-}


### PR DESCRIPTION
## Description

Inspired by Webflow's design, I've changed the builder size breakpoints into a range instead of a single value. Also, when a specific device type is selected the builder is allowed to be resized only in the range associated with that device.

#### Webflow solution

https://user-images.githubusercontent.com/51242349/212045941-07e3b520-4245-4d75-970f-8067a5f4db0f.mp4

## Video or Image

#### Our implementation

https://user-images.githubusercontent.com/51242349/212046607-8982c5cc-9d13-468f-b555-b8c3049f92c3.mp4


## Related Issue(s)

Fixes #2107
