### PR TITLE
fix: use counter instead of id for component instance name

### DIFF
--- a/libs/frontend/domain/element/src/store/element.service.ts
+++ b/libs/frontend/domain/element/src/store/element.service.ts
@@ -589,9 +589,20 @@ element is new parentElement's first child
         let element = this.element(elementId)
 
         if (!element) {
+          const elementTree = Element.getElementTree(targetElement)
+
+          const existingInstances = elementTree?.elementsList.filter(
+            ({ renderComponentType }) => renderComponentType?.id === elementId,
+          )
+
           const component = this.componentService.component(elementId)
-          const name = `${component?.name}_${v4()}`
-          const slug = `${component?.name}_${v4()}`
+
+          const componentInstanceCounter = existingInstances?.length
+            ? ` ${existingInstances.length}`
+            : ''
+
+          const name = `${component?.name}${componentInstanceCounter}`
+          const slug = `${component?.name}${componentInstanceCounter}`
           const renderComponentTypeId = component?.id
           const parentElementId = targetElement.id
           const data = { name, slug, renderComponentTypeId, parentElementId }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
use component instance counter instead of id for component instance name to provide better user experience

## Video or Image

Before            |  After
:-------------------------:|:-------------------------:
<img width="445" alt="Screenshot 2023-01-13 at 15 09 58" src="https://user-images.githubusercontent.com/74900868/212354643-3e473244-fb60-4481-bb84-37c615c3fd0f.png">|<img width="452" alt="Screenshot 2023-01-13 at 16 14 24" src="https://user-images.githubusercontent.com/74900868/212354675-99c131ab-9be7-430d-8275-2e2f8bc82e8e.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #1753 
