### PR TITLE
fix(libs-frontend-domain-renderer): component should be draggable only as a whole

### DIFF
--- a/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
+++ b/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
@@ -37,7 +37,15 @@ export const useDndDropHandler = (
 
     const targetElement = elementService.element(targetElementId)
 
-    if (!targetElement || !dragPosition) {
+    if (!targetElement) {
+      console.error('Target element not found')
+
+      return
+    }
+
+    if (!dragPosition) {
+      console.error('Drag position is required')
+
       return
     }
 
@@ -48,6 +56,7 @@ export const useDndDropHandler = (
 
     let newElement: Nullable<IElement> = null
 
+    // create the new element after the target element
     if (dragPosition === DragPosition.After) {
       createElementDto.prevSiblingId = targetElement.id
       newElement = await elementService.createElementAsNextSibling(
@@ -55,7 +64,9 @@ export const useDndDropHandler = (
       )
     }
 
+    // create the new element before the target element
     if (dragPosition === DragPosition.Before) {
+      // if theres an element before the target, create the new element next to that
       if (targetElement.prevSibling) {
         createElementDto.prevSiblingId = targetElement.prevSibling.id
         newElement = await elementService.createElementAsNextSibling(
@@ -63,6 +74,8 @@ export const useDndDropHandler = (
         )
       }
 
+      // if theres no element before the target, create the new element
+      // as the first child of the target's parent element
       if (!targetElement.prevSibling && targetElement.parentElement?.id) {
         createElementDto.parentElementId = targetElement.parentElement.id
         newElement = await elementService.createElementAsFirstChild(
@@ -71,6 +84,7 @@ export const useDndDropHandler = (
       }
     }
 
+    // create the new element inside the target element as a first child
     if (dragPosition === DragPosition.Inside) {
       createElementDto.parentElementId = targetElement.id
       newElement = await elementService.createElementAsFirstChild(
@@ -94,10 +108,19 @@ export const useDndDropHandler = (
 
     const targetElement = elementService.element(targetElementId)
 
-    if (!targetElement || !dragPosition) {
+    if (!targetElement) {
+      console.error('Target element not found')
+
       return
     }
 
+    if (!dragPosition) {
+      console.error('Drag position is required')
+
+      return
+    }
+
+    // move the dragged element after the target element
     if (dragPosition === DragPosition.After) {
       return await elementService.moveElementAsNextSibling({
         elementId: draggedElementId,
@@ -105,7 +128,9 @@ export const useDndDropHandler = (
       })
     }
 
+    // move the dragged element before the target element
     if (dragPosition === DragPosition.Before) {
+      // if theres an element before the target, move the dragged element next to that
       if (
         targetElement.prevSibling &&
         draggedElementId !== targetElement.prevSibling.id
@@ -116,6 +141,8 @@ export const useDndDropHandler = (
         })
       }
 
+      // if theres no element before the target, move the dragged element
+      // as the first child of the target's parent element
       if (!targetElement.prevSibling && targetElement.parentElement?.id) {
         return await elementService.moveElementAsFirstChild({
           elementId: draggedElementId,
@@ -124,6 +151,7 @@ export const useDndDropHandler = (
       }
     }
 
+    // move the dragged element inside the target element as a first child
     if (dragPosition === DragPosition.Inside) {
       return await elementService.moveElementAsFirstChild({
         elementId: draggedElementId,

--- a/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
+++ b/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
@@ -41,35 +41,40 @@ export const useDndDropHandler = (
       return
     }
 
+    // for not mutating the actual input from the components tab
+    const createElementDto = {
+      ...createElementInput,
+    }
+
     let newElement: Nullable<IElement> = null
 
     if (dragPosition === DragPosition.After) {
-      createElementInput.prevSiblingId = targetElement.id
+      createElementDto.prevSiblingId = targetElement.id
       newElement = await elementService.createElementAsNextSibling(
-        createElementInput,
+        createElementDto,
       )
     }
 
     if (dragPosition === DragPosition.Before) {
       if (targetElement.prevSibling) {
-        createElementInput.prevSiblingId = targetElement.prevSibling.id
+        createElementDto.prevSiblingId = targetElement.prevSibling.id
         newElement = await elementService.createElementAsNextSibling(
-          createElementInput,
+          createElementDto,
         )
       }
 
       if (!targetElement.prevSibling && targetElement.parentElement?.id) {
-        createElementInput.parentElementId = targetElement.parentElement.id
+        createElementDto.parentElementId = targetElement.parentElement.id
         newElement = await elementService.createElementAsFirstChild(
-          createElementInput,
+          createElementDto,
         )
       }
     }
 
     if (dragPosition === DragPosition.Inside) {
-      createElementInput.parentElementId = targetElement.id
+      createElementDto.parentElementId = targetElement.id
       newElement = await elementService.createElementAsFirstChild(
-        createElementInput,
+        createElementDto,
       )
     }
 

--- a/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
+++ b/libs/frontend/domain/renderer/src/element/ElementWrapper.ts
@@ -3,6 +3,7 @@ import type {
   IPropData,
   IRenderer,
 } from '@codelab/frontend/abstract/core'
+import { DATA_COMPONENT_ID } from '@codelab/frontend/abstract/core'
 import type { Nullable, Nullish } from '@codelab/shared/abstract/types'
 import { mergeProps } from '@codelab/shared/utils'
 import { jsx } from '@emotion/react'
@@ -109,8 +110,15 @@ export const ElementWrapper = observer<ElementWrapperProps>(
       return renderOutputWithProps(moreProps)
     }
 
+    const isInsideAComponent = Boolean(globalPropsContext[DATA_COMPONENT_ID])
+    const isComponentRootElement = element.parentComponent && isInsideAComponent
+
+    // we only apply dnd to the root element of a component or elements not inside a component
+    const isDraggable =
+      renderService.isBuilder && (isComponentRootElement || !isInsideAComponent)
+
     // we need to include additional props from dnd so we need to render the element there
-    const WrappedElement = renderService.isBuilder
+    const WrappedElement = isDraggable
       ? makeDraggableElement({ element, makeRenderedElements })
       : makeRenderedElements()
 

--- a/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
+++ b/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
@@ -12,18 +12,17 @@ export const makeDropIndicatorStyle = (
   dragPosition: DragPosition,
   customStyles?: Style,
 ) => {
-  const indicatorStyle: Style = { ...customStyles }
+  const indicatorStyle: Style = { ...customStyles, zIndex: 100 }
 
   switch (dragPosition) {
     case DragPosition.After:
-      indicatorStyle['boxShadow'] = '0px -2px 0px cyan inset, 0px 2px 0px cyan'
+      indicatorStyle['boxShadow'] = '0px 5px 0px cyan'
       break
     case DragPosition.Before:
-      indicatorStyle['boxShadow'] = '0px 2px 0px cyan inset, 0px -2px 0px cyan'
+      indicatorStyle['boxShadow'] = '0px -5px 0px cyan'
       break
     case DragPosition.Inside:
-      indicatorStyle['boxShadow'] =
-        '0px 0px 0px 2px cyan inset, 0px 0px 0px 2px cyan'
+      indicatorStyle['boxShadow'] = '0px 0px 0px 5px cyan'
       break
     default:
       break

--- a/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
+++ b/libs/frontend/domain/renderer/src/utils/makeDropIndicatorStyle.ts
@@ -16,13 +16,14 @@ export const makeDropIndicatorStyle = (
 
   switch (dragPosition) {
     case DragPosition.After:
-      indicatorStyle['boxShadow'] = '0px 5px 0px cyan'
+      indicatorStyle['boxShadow'] = '0px -2px 0px cyan inset, 0px 2px 0px cyan'
       break
     case DragPosition.Before:
-      indicatorStyle['boxShadow'] = '0px -5px 0px cyan'
+      indicatorStyle['boxShadow'] = '0px 2px 0px cyan inset, 0px -2px 0px cyan'
       break
     case DragPosition.Inside:
-      indicatorStyle['boxShadow'] = '0px 0px 0px 5px cyan'
+      indicatorStyle['boxShadow'] =
+        '0px 0px 0px 2px cyan inset, 0px 0px 0px 2px cyan'
       break
     default:
       break


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- the `data-component-id` prop is stored on the global props context in the whole component
- this is used to determine if the element to be rendered is inside a component
- drag and drop feature is only added to component's root element or elements not in a component
- wrap the whole component with `<span>` instead of fragment to be able to apply drag and drop to the whole component (will also work if first children is multiple siblings)
- <span> should have less effect than `<div>` to the layout
- fix creating and moving an element inside an element + before first child
- add `zIndex` to the indicatorStyle so that it shows properly when theres a sibling element and there is no margin between

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/212916296-522aff46-6ab3-43a1-b097-1bdca1f56628.mp4


https://user-images.githubusercontent.com/27695022/212916353-800dc14a-a71d-4ed1-a0f6-1a65156301f5.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2158 
