### PR TITLE
fix: drag and dropping the same atom twice fails the second time

### DIFF
--- a/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/builder/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -135,8 +135,6 @@ PageBuilder.Layout = observer((page) => {
   const pageId = useCurrentPageId()
   const pageBuilderRenderer = builderRenderService.renderers.get(pageId)
   const activeElementTree = builderService.activeElementTree
-  // should be defined by the time, components list renders
-  const pageTree = pageBuilderRenderer?.pageTree?.current
 
   const ConfigPaneComponent = useMemo(
     () =>
@@ -200,7 +198,7 @@ PageBuilder.Layout = observer((page) => {
     <BuilderContext
       builderService={builderService}
       elementService={elementService}
-      elementTree={pageTree}
+      elementTree={activeElementTree}
     >
       <DashboardTemplate
         ConfigPane={ConfigPaneComponent}

--- a/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
+++ b/libs/frontend/domain/builder/src/dnd/useDndDropHandlers.ts
@@ -56,6 +56,27 @@ export const useDndDropHandler = (
 
     let newElement: Nullable<IElement> = null
 
+    const existingSameAtoms = elementTree.elementsList.filter(({ atom }) => {
+      return atom?.id === createElementDto.atomId
+    })
+
+    if (existingSameAtoms.length) {
+      const newCount = existingSameAtoms.length + 1
+      createElementDto.slug = `${createElementDto.slug}-${newCount}`
+    }
+
+    // theres still a chance that the auto-incremented slug already exists
+    // we can prevent it from being sent to backend by throwing early
+    const hasSameSlug = elementTree.elementsList.some(
+      ({ slug }) => slug === createElementDto.slug,
+    )
+
+    if (hasSameSlug) {
+      throw new Error(
+        `Found element with the same slug: ${createElementDto.slug}`,
+      )
+    }
+
     // create the new element after the target element
     if (dragPosition === DragPosition.After) {
       createElementDto.prevSiblingId = targetElement.id


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
- Add auto increment logic to the slug of the new dnd'ed element if theres an existing same atoms in the current element tree
- Theres still a chance that the new slug is also already existing in the current element tree. To keep the solution simple for now, it will throw an error if the same slug already exists. Though it should rarely happen, these are some cases it could happen:
  - a different atom with slug `antdesignbutton-5` then you just dnd'ed the new actual 5th button
  - renamed the slug of the last same atom from `antdesignbutton-4` to `antdesignbutton-5` then you just dnd'ed the new actual 5th button
- I also notice that the same page element tree is being used in the builder context when in the component view and if there is an `antdesignbutton-5` in the page tree, dnd'ing a 5th button in the component view won't work as it thought theres already an element with the same slug but its actually on a different tree
  - fixed this by passing the `activeElementTree` instead of the `pageTree` so that the tree in the builder context is the actual component tree when in component view
  - this is still working on page view
  - fixing this also fixes the bug where component preview is not showing when clicking on the newly created element in the component

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/213179277-a2b786a0-e21b-4fec-a15b-317115a24cfb.mp4


https://user-images.githubusercontent.com/27695022/213179302-cc7ea866-6138-49c1-a742-c2eadc0d6bc5.mp4


In this video, this is the edge case where theres a duplicate autoincremented slug. I renamed the slug of the last created button so that it will be the same to the new one. Instead of the cryptic error message from the BE, we throw early with a custom error message (we can improve the displaying of thrown error messages in another tasks)

https://user-images.githubusercontent.com/27695022/213179618-3f0dd224-23cf-41c7-8bd0-a0ff8dc876ef.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2182 
Fixes #2183 
