### PR TITLE
fix: Atoms are not populated with default values

### DIFF
--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-ComponentTabContainer/GetComponentItem.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-ComponentTabContainer/GetComponentItem.tsx
@@ -1,8 +1,15 @@
-import type { IBuilderComponent } from '@codelab/frontend/abstract/core'
+import type {
+  IBuilderComponent,
+  IFieldDefaultValue,
+  IInterfaceType,
+} from '@codelab/frontend/abstract/core'
 import { BuilderDndType } from '@codelab/frontend/abstract/core'
+import { useStore } from '@codelab/frontend/presenter/container'
 import { createSlug } from '@codelab/frontend/shared/utils'
+import type { Maybe, Nullish } from '@codelab/shared/abstract/types'
 import { antDesignIconPrefix } from '@codelab/shared/data'
 import { Card } from 'antd'
+import { isNil } from 'ramda'
 import React, { useMemo } from 'react'
 import tw from 'twin.macro'
 import { useCreateElementDraggable } from '../../../dnd/useCreateElementDraggable'
@@ -11,14 +18,41 @@ interface DraggableGetComponentItemProps {
   component: IBuilderComponent
 }
 
+/**
+ * generates a JSON containing api fields that has a default value
+ * that will be saved as props for the new element created
+ */
+const makeDefaultProps = (typeApi: Maybe<IInterfaceType>) => {
+  const fields = typeApi?.fields ?? []
+
+  const defaultProps = fields.reduce<
+    Record<string, Nullish<IFieldDefaultValue>>
+  >((acc, field) => {
+    if (!isNil(field.defaultValues)) {
+      acc[field.key] = field.defaultValues
+    }
+
+    return acc
+  }, {})
+
+  return JSON.stringify(defaultProps)
+}
+
 export const DraggableGetComponentItem = ({
   component,
 }: DraggableGetComponentItemProps) => {
+  const { typeService } = useStore()
+
   const createElementInput = useMemo(() => {
+    // Atoms are interface type
+    // by the time this is called, it should be already available because of the query GetRenderedPageAndCommonAppData
+    const typeApi = typeService.type(component.api.id) as Maybe<IInterfaceType>
+
     return {
       name: component.name,
       atomId: component.id,
       slug: createSlug(component.name),
+      propsData: makeDefaultProps(typeApi),
     }
   }, [component])
 

--- a/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-ComponentTabContainer/GetComponentItem.tsx
+++ b/libs/frontend/domain/builder/src/sections/config-pane/ConfigPane-ComponentTabContainer/GetComponentItem.tsx
@@ -1,15 +1,8 @@
-import type {
-  IBuilderComponent,
-  IFieldDefaultValue,
-  IInterfaceType,
-} from '@codelab/frontend/abstract/core'
+import type { IBuilderComponent } from '@codelab/frontend/abstract/core'
 import { BuilderDndType } from '@codelab/frontend/abstract/core'
-import { useStore } from '@codelab/frontend/presenter/container'
 import { createSlug } from '@codelab/frontend/shared/utils'
-import type { Maybe, Nullish } from '@codelab/shared/abstract/types'
 import { antDesignIconPrefix } from '@codelab/shared/data'
 import { Card } from 'antd'
-import { isNil } from 'ramda'
 import React, { useMemo } from 'react'
 import tw from 'twin.macro'
 import { useCreateElementDraggable } from '../../../dnd/useCreateElementDraggable'
@@ -18,41 +11,14 @@ interface DraggableGetComponentItemProps {
   component: IBuilderComponent
 }
 
-/**
- * generates a JSON containing api fields that has a default value
- * that will be saved as props for the new element created
- */
-const makeDefaultProps = (typeApi: Maybe<IInterfaceType>) => {
-  const fields = typeApi?.fields ?? []
-
-  const defaultProps = fields.reduce<
-    Record<string, Nullish<IFieldDefaultValue>>
-  >((acc, field) => {
-    if (!isNil(field.defaultValues)) {
-      acc[field.key] = field.defaultValues
-    }
-
-    return acc
-  }, {})
-
-  return JSON.stringify(defaultProps)
-}
-
 export const DraggableGetComponentItem = ({
   component,
 }: DraggableGetComponentItemProps) => {
-  const { typeService } = useStore()
-
   const createElementInput = useMemo(() => {
-    // Atoms are interface type
-    // by the time this is called, it should be already available because of the query GetRenderedPageAndCommonAppData
-    const typeApi = typeService.type(component.api.id) as Maybe<IInterfaceType>
-
     return {
       name: component.name,
       atomId: component.id,
       slug: createSlug(component.name),
-      propsData: makeDefaultProps(typeApi),
     }
   }, [component])
 

--- a/libs/frontend/domain/element/src/store/api.utils.ts
+++ b/libs/frontend/domain/element/src/store/api.utils.ts
@@ -1,6 +1,8 @@
 import type {
   ICreateElementDTO,
   IElement,
+  IFieldDefaultValue,
+  IInterfaceType,
   IUpdateElementDTO,
 } from '@codelab/frontend/abstract/core'
 import { createSlug } from '@codelab/frontend/shared/utils'
@@ -8,7 +10,9 @@ import type {
   ElementCreateInput,
   ElementUpdateInput,
 } from '@codelab/shared/abstract/codegen'
+import type { Maybe } from '@codelab/shared/abstract/types'
 import { connectNode, reconnectNode } from '@codelab/shared/data'
+import { isNil } from 'ramda'
 import { v4 } from 'uuid'
 
 //
@@ -104,4 +108,25 @@ export const makeUpdateInput = (
     renderComponentType,
     renderIfExpression: input.renderIfExpression,
   }
+}
+
+/**
+ * Generates a JSON containing api fields that has a default value
+ * that will be saved as props for the new element created
+ */
+export const makeDefaultProps = (typeApi: Maybe<IInterfaceType>) => {
+  const fields = typeApi?.fields ?? []
+
+  const defaultProps = fields.reduce<Record<string, IFieldDefaultValue>>(
+    (acc, field) => {
+      if (!isNil(field.defaultValues)) {
+        acc[field.key] = field.defaultValues
+      }
+
+      return acc
+    },
+    {},
+  )
+
+  return JSON.stringify(defaultProps)
 }


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
The issue is that we are not passing the `propsData` when creating an element.

We need to include `propsData` which should be a JSON that contains api fields that has a default value. Upon creation of the element, we need to check which type fields have a `defaultValues` not null or undefined. Then we generate the JSON and pass it on the `propsData` and it should create a `prop` connected to the created element, and has default values.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/213431366-18ce92d3-e244-46b5-bda2-43a297b47658.mp4


https://user-images.githubusercontent.com/27695022/213431410-2f91480e-8cda-46f9-8743-0a19d6f2e944.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2070 
