### PR TITLE
fix: builder is rendering too much when dragging into the builder

### DIFF
--- a/libs/frontend/domain/renderer/src/Renderer.tsx
+++ b/libs/frontend/domain/renderer/src/Renderer.tsx
@@ -5,7 +5,7 @@ import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
 import ErrorBoundary from 'antd/lib/alert/ErrorBoundary'
 import { observer } from 'mobx-react-lite'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 export type RendererRoot = Pick<IRenderer, 'renderRoot'>
 /**
@@ -39,6 +39,9 @@ const emotionCache = createCache({
 
 export const Renderer = observer<WithStyleProp<RendererRoot>, HTMLDivElement>(
   ({ renderRoot, style = {} }, ref) => {
+    // this prevents re-rendering too much
+    const renderedRoot = useMemo(() => renderRoot(), [])
+
     return (
       <ErrorBoundary>
         <CacheProvider value={emotionCache}>
@@ -47,7 +50,7 @@ export const Renderer = observer<WithStyleProp<RendererRoot>, HTMLDivElement>(
             ref={ref}
             style={{ minHeight: '100%', transform: 'translatex(0)', ...style }}
           >
-            {renderRoot()}
+            {renderedRoot}
           </div>
         </CacheProvider>
       </ErrorBoundary>


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description

<!-- This is a short description on the Pull Request -->
We could do more optimization around the builder so that it doesn't cause too much re-rendering. But for now, we can use `useMemo` on the `renderRoot` to prevent too much re-rendering.

## Video or Image

<!-- Add video or image showing how the new feature works -->

https://user-images.githubusercontent.com/27695022/213487452-f79f5b55-de93-4b98-8b2b-0f0ab7e9a2b6.mp4



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #2189 
