### PR TITLE
refactor: remove tree service from app model

### DIFF
--- a/libs/frontend/domain/app/src/store/app.model.ts
+++ b/libs/frontend/domain/app/src/store/app.model.ts
@@ -1,6 +1,5 @@
 import type { IApp, IPage, IStore } from '@codelab/frontend/abstract/core'
 import { IAppDTO } from '@codelab/frontend/abstract/core'
-import { ElementTreeService } from '@codelab/frontend/domain/element'
 import { pageRef } from '@codelab/frontend/domain/page'
 import { storeRef } from '@codelab/frontend/domain/store'
 import merge from 'lodash/merge'
@@ -8,8 +7,8 @@ import { computed } from 'mobx'
 import type { Ref } from 'mobx-keystone'
 import {
   detach,
-  ExtendedModel,
   idProp,
+  Model,
   model,
   modelAction,
   prop,
@@ -31,7 +30,7 @@ const hydrate = (app: IAppDTO) => {
 
 @model('@codelab/App')
 export class App
-  extends ExtendedModel(ElementTreeService, {
+  extends Model({
     id: idProp,
     ownerId: prop<string>(),
     name: prop<string>().withSetter(),


### PR DESCRIPTION
<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(libs-ui-component): must begin with lowercase` -->

## Description
Because provider tree was moved to `_app` page, app model doesn't need to extend `ElementTreeService` 
<!-- This is a short description on the Pull Request -->

## Video or Image

<!-- Add video or image showing how the new feature works -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged -->

Fixes #
